### PR TITLE
Fix trailing space in SQL query

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -194,7 +194,7 @@ async fn update_last_list_message_id(
     message_id: MessageId,
 ) -> Result<()> {
     sqlx::query(
-        "INSERT INTO chat_state (chat_id, last_list_message_id) VALUES (?, ?) 
+        "INSERT INTO chat_state (chat_id, last_list_message_id) VALUES (?, ?)
          ON CONFLICT(chat_id) DO UPDATE SET last_list_message_id = excluded.last_list_message_id",
     )
     .bind(chat_id.0)


### PR DESCRIPTION
## Summary
- remove stray whitespace from SQL query line

## Testing
- `cargo fmt`

------
https://chatgpt.com/codex/tasks/task_e_684328ea273c832da38376410b605d7d