### PR TITLE
Improve sqlite URL mode logic

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,11 @@ async fn main() -> Result<()> {
     // This is crucial for the first run on a new volume, as it tells SQLite
     // to create the database file if it's missing.
     if db_url.starts_with("sqlite:") && !db_url.contains("mode=") {
-        db_url.push_str("?mode=rwc");
+        if db_url.contains('?') {
+            db_url.push_str("&mode=rwc");
+        } else {
+            db_url.push_str("?mode=rwc");
+        }
     }
 
     tracing::info!("Connecting to database at: {}", &db_url);


### PR DESCRIPTION
## Summary
- when configuring the SQLite URL, add `mode=rwc` via `&` or `?` as needed
- run formatting

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684328ebf0ac832d97e34dca484864b5