### PR TITLE
Fix failing CI by formatting tests

### DIFF
--- a/tests/formatting.rs
+++ b/tests/formatting.rs
@@ -1,9 +1,17 @@
-use shopbot::{format_list, format_delete_list, Item};
+use shopbot::{format_delete_list, format_list, Item};
 
 fn sample_items() -> Vec<Item> {
     vec![
-        Item { id: 1, text: "Apples".to_string(), done: false },
-        Item { id: 2, text: "Milk".to_string(), done: true },
+        Item {
+            id: 1,
+            text: "Apples".to_string(),
+            done: false,
+        },
+        Item {
+            id: 2,
+            text: "Milk".to_string(),
+            done: true,
+        },
     ]
 }
 


### PR DESCRIPTION
## Summary
- format tests per rustfmt requirements so CI passes

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all -- -D warnings`
- `cargo test -- --color=never`


------
https://chatgpt.com/codex/tasks/task_e_68433608db50832db64c8d1baccf5c06