### PR TITLE
Defer item deletion until Done action

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,3 +2,4 @@
 
 - Always run `cargo fmt --all -- --check` and `cargo test --all --no-fail-fast` before committing.
 - Use clear commit messages that describe the change.
+- Avoid global state. Persist temporary data such as deletion selections and any notice messages in the database.

--- a/tests/formatting.rs
+++ b/tests/formatting.rs
@@ -32,18 +32,19 @@ fn test_format_list() {
 
 #[test]
 fn test_format_delete_list() {
-    let items = sample_items();
-    let (text, keyboard) = format_delete_list(&items);
+    use std::collections::HashSet;
 
-    assert_eq!(
-        text,
-        "Tap an item to delete it. Tap 'Done Deleting' when finished."
-    );
+    let items = sample_items();
+    let mut selected = HashSet::new();
+    selected.insert(1);
+    let (text, keyboard) = format_delete_list(&items, &selected);
+
+    assert_eq!(text, "Select items to delete, then tap 'Done Deleting'.");
 
     let labels: Vec<&str> = keyboard
         .inline_keyboard
         .iter()
         .map(|row| row[0].text.as_str())
         .collect();
-    assert_eq!(labels, vec!["❌ Apples", "❌ Milk", "✅ Done Deleting"]);
+    assert_eq!(labels, vec!["☑️ Apples", "❌ Milk", "✅ Done Deleting"]);
 }


### PR DESCRIPTION
## Summary
- defer deletion until user taps **Done Deleting**
- keep a notice message in chat while delete mode is active
- track item selections for deletion using the database instead of globals
- clarify the guidance on avoiding global state in `AGENTS.md`

## Testing
- `cargo fmt --all -- --check`
- `cargo test --all --no-fail-fast`


------
https://chatgpt.com/codex/tasks/task_e_684349be59a8832d916d535b74680fa2