### PR TITLE
Handle multiple delete menus safely

### DIFF
--- a/migrations/20240102000000_add_dm_message.sql
+++ b/migrations/20240102000000_add_dm_message.sql
@@ -1,0 +1,2 @@
+-- Add column to track active delete DM message
+ALTER TABLE delete_session ADD COLUMN dm_message_id INTEGER;


### PR DESCRIPTION
## Summary
- track DM message IDs for delete sessions
- ignore callbacks from stale menus
- clean up old messages when starting a new delete session
- add database migration for the new column

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`


------
https://chatgpt.com/codex/tasks/task_e_684356829178832d9c148925b8c2620f