### PR TITLE
Improve SQLite url handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,16 @@ This is a small Telegram bot for keeping a collaborative grocery list. The code 
 You'll need a recent Rust toolchain with `sqlx` and `teloxide` dependencies. The CI configuration uses `cargo fmt`, `cargo clippy` and `cargo test` so running them locally is a good idea too.
 
 The bot now manages its database schema through embedded SQLx migrations. When
+
 the application starts it will automatically run any migrations found in the
 `migrations/` directory.
+
+## Configuration
+
+The bot reads its settings from environment variables:
+
+* `TELOXIDE_TOKEN` - your Telegram bot token.
+* `DB_URL` - SQLite connection string (defaults to `sqlite:shopping.db`).
+  The application ensures the database file is created if it does not exist.
 
 Have fun and vibe responsibly!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,12 +34,15 @@ pub async fn run() -> Result<()> {
     // Read the database URL from the environment, with a fallback for local dev.
     let mut db_url = env::var("DB_URL").unwrap_or_else(|_| "sqlite:shopping.db".to_string());
 
-    // --- THIS IS THE FIX ---
-    // Ensure the connection string has the 'create if not exists' flag.
-    // This is crucial for the first run on a new volume, as it tells SQLite
-    // to create the database file if it's missing.
+    // Ensure the connection string has the 'create if not exists' flag so the
+    // database file is created on first run. If other parameters are present
+    // append `&mode=rwc`, otherwise start a new query string.
     if db_url.starts_with("sqlite:") && !db_url.contains("mode=") {
-        db_url.push_str("?mode=rwc");
+        if db_url.contains('?') {
+            db_url.push_str("&mode=rwc");
+        } else {
+            db_url.push_str("?mode=rwc");
+        }
     }
 
     tracing::info!("Connecting to database at: {}", &db_url);


### PR DESCRIPTION
## Summary
- ensure DB_URL appends `mode=rwc` correctly when query params are present
- document environment variables used by the bot

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`

------
https://chatgpt.com/codex/tasks/task_e_68435cfb5488832dbe75e4a4e5757b44