### PR TITLE
Improve test coverage and update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,5 +19,8 @@ jobs:
         run: cargo fmt --all -- --check
       - name: Cargo clippy
         run: cargo clippy --all -- -D warnings
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
       - name: Cargo test
-        run: cargo test --all --no-fail-fast
+        run: cargo nextest run --all

--- a/src/db.rs
+++ b/src/db.rs
@@ -214,3 +214,35 @@ pub async fn clear_delete_session(db: &Pool<Sqlite>, user_id: i64) -> Result<()>
         .await?;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn parse_selected_empty() {
+        let set = parse_selected("");
+        assert!(set.is_empty());
+    }
+
+    #[test]
+    fn join_selected_sorts() {
+        let mut set = HashSet::new();
+        set.insert(5);
+        set.insert(3);
+        set.insert(7);
+        assert_eq!(join_selected(&set), "3,5,7");
+    }
+
+    #[test]
+    fn parse_join_roundtrip() {
+        let mut original = HashSet::new();
+        original.insert(2);
+        original.insert(1);
+        original.insert(9);
+        let joined = join_selected(&original);
+        let parsed = parse_selected(&joined);
+        assert_eq!(original, parsed);
+    }
+}


### PR DESCRIPTION
## Summary
- add new unit tests for delete session helper functions
- run tests via `cargo nextest` in CI

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`


------
https://chatgpt.com/codex/tasks/task_e_68436b2e3684832d885ca79dc681bf21