### PR TITLE
Improve docs and add text parsing tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Set these environment variables before running:
 
 - `TELOXIDE_TOKEN` – Telegram bot token from @BotFather
 - `DB_URL` – optional SQLite connection string (defaults to `sqlite:shopping.db`)
+- `RUST_LOG` – optional logging level (e.g. `info` or `debug`)
 
 The database file is created automatically if needed. Embedded SQLx migrations in the `migrations/` directory are executed on startup.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ mod db;
 mod handlers;
 
 pub use db::Item;
-pub use handlers::{format_delete_list, format_list};
+pub use handlers::{format_delete_list, format_list, parse_item_line};
 
 use handlers::{
     add_items_from_text, archive, callback_handler, enter_delete_mode, help, nuke_list, send_list,

--- a/tests/text_parsing.rs
+++ b/tests/text_parsing.rs
@@ -1,0 +1,16 @@
+use shopbot::parse_item_line;
+
+#[test]
+fn test_parse_item_line() {
+    // Normal line
+    assert_eq!(parse_item_line("Milk"), Some("Milk".to_string()));
+    // Leading emoji
+    assert_eq!(parse_item_line("✅ Apples"), Some("Apples".to_string()));
+    assert_eq!(parse_item_line("🛒Bread"), Some("Bread".to_string()));
+    // Extra spaces
+    assert_eq!(parse_item_line("  Carrots  "), Some("Carrots".to_string()));
+    // Archived marker
+    assert_eq!(parse_item_line("--- Archived List ---"), None);
+    // Empty line when only an emoji and spaces
+    assert_eq!(parse_item_line("✅   "), None);
+}


### PR DESCRIPTION
## Summary
- document `RUST_LOG` configuration in README
- expose new `parse_item_line` helper
- use helper in `add_items_from_text`
- add unit test for parsing lines

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`


------
https://chatgpt.com/codex/tasks/task_e_6843765763b0832da82b8afc0dd42dfc