### PR TITLE
Add /share feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Send any message to the bot. Every non-empty line becomes an item. The bot respo
 - `/list` – show the list again
 - `/archive` – archive the current list and start a new one
 - `/delete` – select items to remove
+- `/share` – send the list as plain text
 - `/nuke` – wipe the list completely
 
 ## Installation

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,10 +8,11 @@ mod db;
 mod handlers;
 
 pub use db::Item;
-pub use handlers::{format_delete_list, format_list, parse_item_line};
+pub use handlers::{format_delete_list, format_list, format_plain_list, parse_item_line};
 
 use handlers::{
     add_items_from_text, archive, callback_handler, enter_delete_mode, help, nuke_list, send_list,
+    share_list,
 };
 // ──────────────────────────────────────────────────────────────
 // Main application setup
@@ -73,6 +74,8 @@ pub async fn run() -> Result<()> {
         Archive,
         #[command(description = "show a temporary panel to delete items from the list.")]
         Delete,
+        #[command(description = "send the list as plain text for copying.")]
+        Share,
         #[command(description = "completely delete the current list.")]
         Nuke,
     }
@@ -89,6 +92,7 @@ pub async fn run() -> Result<()> {
                             Command::List => send_list(bot, msg.chat.id, &db).await?,
                             Command::Archive => archive(bot, msg.chat.id, &db).await?,
                             Command::Delete => enter_delete_mode(bot, msg, &db).await?,
+                            Command::Share => share_list(bot, msg.chat.id, &db).await?,
                             Command::Nuke => nuke_list(bot, msg, &db).await?,
                         }
                         Ok(())

--- a/tests/formatting.rs
+++ b/tests/formatting.rs
@@ -1,4 +1,4 @@
-use shopbot::{format_delete_list, format_list, Item};
+use shopbot::{format_delete_list, format_list, format_plain_list, Item};
 
 fn sample_items() -> Vec<Item> {
     vec![
@@ -47,4 +47,11 @@ fn test_format_delete_list() {
         .map(|row| row[0].text.as_str())
         .collect();
     assert_eq!(labels, vec!["☑️ Apples", "❌ Milk", "✅ Done Deleting"]);
+}
+
+#[test]
+fn test_format_plain_list() {
+    let items = sample_items();
+    let text = format_plain_list(&items);
+    assert_eq!(text, "• Apples\n• Milk\n");
 }


### PR DESCRIPTION
## Summary
- show `/share` command in README and help text
- add plain text list formatter and new `share_list` handler
- expose `format_plain_list` API and `/share` command in router
- test `format_plain_list`

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`


------
https://chatgpt.com/codex/tasks/task_e_68437f0b1148832dbf96a1d9ff07e559