### PR TITLE
Update prompts and canonicalize GPT items

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -103,6 +103,14 @@ pub fn parse_item_line(line: &str) -> Option<String> {
     }
 }
 
+fn capitalize_first(text: &str) -> String {
+    let mut chars = text.chars();
+    match chars.next() {
+        Some(c) => c.to_uppercase().chain(chars).collect(),
+        None => String::new(),
+    }
+}
+
 use crate::stt::{
     parse_items, parse_items_gpt, parse_voice_items, parse_voice_items_gpt, transcribe_audio,
     SttConfig, DEFAULT_PROMPT,
@@ -143,7 +151,8 @@ pub async fn add_items_from_voice(
             };
             let mut added = 0;
             for item in items {
-                add_item(&db, msg.chat.id, &item).await?;
+                let cap = capitalize_first(&item);
+                add_item(&db, msg.chat.id, &cap).await?;
                 added += 1;
             }
             if added > 0 {
@@ -211,7 +220,8 @@ pub async fn add_items_from_parsed_text(
 
     let mut added = 0;
     for item in items {
-        add_item(&db, msg.chat.id, &item).await?;
+        let cap = capitalize_first(&item);
+        add_item(&db, msg.chat.id, &cap).await?;
         added += 1;
     }
 

--- a/src/stt.rs
+++ b/src/stt.rs
@@ -9,8 +9,7 @@ pub struct SttConfig {
 }
 
 /// Default instructions passed to GPT-based transcription models.
-pub const DEFAULT_PROMPT: &str =
-    "List the grocery items mentioned, separated by commas or the word 'and'.";
+pub const DEFAULT_PROMPT: &str = "List the items mentioned, separated by commas or the word 'and'.";
 
 #[derive(Deserialize)]
 struct TranscriptionResponse {
@@ -77,7 +76,7 @@ pub async fn transcribe_audio_test(
 /// The text is split on commas, newlines and the word "and". Each segment is
 /// then cleaned via [`crate::handlers::parse_item_line`]. Empty segments are
 /// ignored.
-/// Split a text string into individual grocery items.
+/// Split a text string into individual items.
 ///
 /// The input is split on commas, newlines and the word "and". Each segment is
 /// then cleaned via [`crate::handlers::parse_item_line`]. Empty segments are
@@ -116,7 +115,7 @@ struct ItemsJson {
 
 const OPENAI_CHAT_URL: &str = "https://api.openai.com/v1/chat/completions";
 
-/// Use the OpenAI Chat API to parse grocery items from arbitrary text.
+/// Use the OpenAI Chat API to parse items from arbitrary text.
 ///
 /// The model is instructed to return a JSON object with an `items` array. The
 /// returned list is cleaned with [`crate::handlers::parse_item_line`].
@@ -137,7 +136,7 @@ pub async fn parse_items_gpt_inner(api_key: &str, text: &str, url: &str) -> Resu
         "messages": [
             {
                 "role": "system",
-                "content": "Extract the grocery items from the user's text. Respond with a JSON object like {\"items\": [\"apples\"]}.",
+                "content": "Extract the items from the user's text. Respond with a JSON object like {\"items\": [\"apples\"]}.",
             },
             { "role": "user", "content": text },
         ]


### PR DESCRIPTION
## Summary
- relax voice transcription system prompt
- remove grocery wording from GPT parsing docs
- capitalize each item added through `/parse`

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`


------
https://chatgpt.com/codex/tasks/task_e_684416e683bc832d9eb1031b4eaa60b2