### PR TITLE
Add tracing debug logs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 - Always run `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --all --no-fail-fast` before committing.
 - Use clear commit messages that describe the change.
+- Ensure new functionality is observable via logging. Emit at least debug logs
+  for important operations so behavior can be traced in production.
 - Avoid global state. Persist temporary data such as deletion selections and any notice messages in the database.
 - Keep the `migrations/` directory up to date whenever the database schema changes so that embedded migrations remain in sync.
 

--- a/fly.toml
+++ b/fly.toml
@@ -6,7 +6,7 @@ dockerfile = 'Dockerfile'
 image_tag = "latest"
 
 [env]
-RUST_LOG = 'info'
+RUST_LOG = 'trace'
 DB_URL = 'sqlite:///data/shopping.db'
 
 [[mounts]]


### PR DESCRIPTION
## Summary
- sprinkle debug/trace logging across DB and handlers
- bump RUST_LOG to `trace` in fly.toml
- state that new functionality should be observable via logging in `AGENTS.md`

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`


------
https://chatgpt.com/codex/tasks/task_e_68441fed903c832d816aad6d1618ea1c