### PR TITLE
Release 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0] - Unreleased
+
+## [0.1.0] - 2025-06-07
 1. Initial release of the Telegram shopping list bot.
 2. Each chat has a single list; send text to add items line by line.
 3. Inline checkbox buttons allow marking items as bought.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1980,7 +1980,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shopbot"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "dotenvy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shopbot"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## Summary
- cut release 0.1.0 in the changelog
- bump version to 0.2.0 for ongoing work

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`


------
https://chatgpt.com/codex/tasks/task_e_68445f3aa3a8832da9e34f10a877ec0a