### PR TITLE
Add completion indicator when list fully checked off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [0.2.0] - Unreleased
 1. Add items by sending a photo using OpenAI vision to detect items automatically.
+2. Display a check mark when every item in the list is checked off.
 
 ## [0.1.0] - 2025-06-07
 1. Initial release of the Telegram shopping list bot.

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -30,6 +30,8 @@ pub fn format_list(items: &[Item]) -> (String, InlineKeyboardMarkup) {
     let mut text = String::new();
     let mut keyboard_buttons = Vec::new();
 
+    let all_done = items.iter().all(|i| i.done);
+
     for item in items {
         let mark = if item.done { "✅" } else { "🛒" };
         let button_text = if item.done {
@@ -42,6 +44,11 @@ pub fn format_list(items: &[Item]) -> (String, InlineKeyboardMarkup) {
             button_text,
             item.id.to_string(),
         )]);
+    }
+
+    if all_done && !items.is_empty() {
+        tracing::debug!("List fully checked out");
+        text.push_str("✅ All items checked off.\n");
     }
 
     (text, InlineKeyboardMarkup::new(keyboard_buttons))

--- a/tests/formatting.rs
+++ b/tests/formatting.rs
@@ -15,6 +15,21 @@ fn sample_items() -> Vec<Item> {
     ]
 }
 
+fn all_done_items() -> Vec<Item> {
+    vec![
+        Item {
+            id: 1,
+            text: "Apples".to_string(),
+            done: true,
+        },
+        Item {
+            id: 2,
+            text: "Milk".to_string(),
+            done: true,
+        },
+    ]
+}
+
 #[test]
 fn test_format_list() {
     let items = sample_items();
@@ -54,4 +69,11 @@ fn test_format_plain_list() {
     let items = sample_items();
     let text = format_plain_list(&items);
     assert_eq!(text, "• Apples\n• Milk\n");
+}
+
+#[test]
+fn test_format_list_all_done() {
+    let items = all_done_items();
+    let (text, _keyboard) = format_list(&items);
+    assert!(text.ends_with("✅ All items checked off.\n"));
 }


### PR DESCRIPTION
## Summary
- show a check mark message when every item is checked
- cover this behavior in formatting tests
- document the change in the changelog

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`


------
https://chatgpt.com/codex/tasks/task_e_68447f54b3b4832d876670a6aaa71eff