### PR TITLE
Revise completion indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [0.2.0] - Unreleased
 1. Add items by sending a photo using OpenAI vision to detect items automatically.
-2. Display a check mark when every item in the list is checked off.
+2. Items show green checkmarks when the entire list is checked off.
+3. Checkbox icons indicate item status and trashcan icons appear in deletion mode.
 
 ## [0.1.0] - 2025-06-07
 1. Initial release of the Telegram shopping list bot.

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -33,11 +33,12 @@ pub fn format_list(items: &[Item]) -> (String, InlineKeyboardMarkup) {
     let all_done = items.iter().all(|i| i.done);
 
     for item in items {
-        let mark = if item.done { "✅" } else { "🛒" };
-        let button_text = if item.done {
-            format!("✅ {}", item.text)
+        let (mark, button_text) = if all_done {
+            ("✅", format!("✅ {}", item.text))
+        } else if item.done {
+            ("☑️", format!("☑️ {}", item.text))
         } else {
-            item.text.clone()
+            ("⬜", format!("⬜ {}", item.text))
         };
         text.push_str(&format!("{} {}\n", mark, item.text));
         keyboard_buttons.push(vec![InlineKeyboardButton::callback(
@@ -48,7 +49,6 @@ pub fn format_list(items: &[Item]) -> (String, InlineKeyboardMarkup) {
 
     if all_done && !items.is_empty() {
         tracing::debug!("List fully checked out");
-        text.push_str("✅ All items checked off.\n");
     }
 
     (text, InlineKeyboardMarkup::new(keyboard_buttons))
@@ -64,7 +64,7 @@ pub fn format_delete_list(
 
     for item in items {
         let button_text = if selected.contains(&item.id) {
-            format!("☑️ {}", item.text)
+            format!("🗑️ {}", item.text)
         } else {
             format!("❌ {}", item.text)
         };
@@ -76,7 +76,7 @@ pub fn format_delete_list(
     }
 
     keyboard_buttons.push(vec![InlineKeyboardButton::callback(
-        "✅ Done Deleting",
+        "🗑️ Done Deleting",
         "delete_done",
     )]);
 
@@ -103,7 +103,9 @@ pub fn parse_item_line(line: &str) -> Option<String> {
         return None;
     }
 
-    let cleaned = line.trim_start_matches(['✅', '🛒']).trim();
+    let cleaned = line
+        .trim_start_matches(['☑', '✅', '⬜', '🛒', '\u{fe0f}'])
+        .trim();
 
     if cleaned.is_empty() {
         tracing::trace!("Line empty after cleaning");

--- a/tests/formatting.rs
+++ b/tests/formatting.rs
@@ -35,14 +35,14 @@ fn test_format_list() {
     let items = sample_items();
     let (text, keyboard) = format_list(&items);
 
-    assert_eq!(text, "🛒 Apples\n✅ Milk\n");
+    assert_eq!(text, "⬜ Apples\n☑️ Milk\n");
 
     let labels: Vec<&str> = keyboard
         .inline_keyboard
         .iter()
         .map(|row| row[0].text.as_str())
         .collect();
-    assert_eq!(labels, vec!["Apples", "✅ Milk"]);
+    assert_eq!(labels, vec!["⬜ Apples", "☑️ Milk"]);
 }
 
 #[test]
@@ -61,7 +61,7 @@ fn test_format_delete_list() {
         .iter()
         .map(|row| row[0].text.as_str())
         .collect();
-    assert_eq!(labels, vec!["☑️ Apples", "❌ Milk", "✅ Done Deleting"]);
+    assert_eq!(labels, vec!["🗑️ Apples", "❌ Milk", "🗑️ Done Deleting"]);
 }
 
 #[test]
@@ -74,6 +74,13 @@ fn test_format_plain_list() {
 #[test]
 fn test_format_list_all_done() {
     let items = all_done_items();
-    let (text, _keyboard) = format_list(&items);
-    assert!(text.ends_with("✅ All items checked off.\n"));
+    let (text, keyboard) = format_list(&items);
+    assert_eq!(text, "✅ Apples\n✅ Milk\n");
+
+    let labels: Vec<&str> = keyboard
+        .inline_keyboard
+        .iter()
+        .map(|row| row[0].text.as_str())
+        .collect();
+    assert_eq!(labels, vec!["✅ Apples", "✅ Milk"]);
 }

--- a/tests/text_parsing.rs
+++ b/tests/text_parsing.rs
@@ -5,12 +5,12 @@ fn test_parse_item_line() {
     // Normal line
     assert_eq!(parse_item_line("Milk"), Some("Milk".to_string()));
     // Leading emoji
-    assert_eq!(parse_item_line("✅ Apples"), Some("Apples".to_string()));
-    assert_eq!(parse_item_line("🛒Bread"), Some("Bread".to_string()));
+    assert_eq!(parse_item_line("☑️ Apples"), Some("Apples".to_string()));
+    assert_eq!(parse_item_line("⬜Bread"), Some("Bread".to_string()));
     // Extra spaces
     assert_eq!(parse_item_line("  Carrots  "), Some("Carrots".to_string()));
     // Archived marker
     assert_eq!(parse_item_line("--- Archived List ---"), None);
     // Empty line when only an emoji and spaces
-    assert_eq!(parse_item_line("✅   "), None);
+    assert_eq!(parse_item_line("☑️   "), None);
 }


### PR DESCRIPTION
## Summary
- items get green checkmarks when list fully checked
- remove trailing completion message
- update tests and changelog

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`


------
https://chatgpt.com/codex/tasks/task_e_6844a991d20c832dbe0442efcc6c874c