### PR TITLE
Improve delete button icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 ## [0.2.0] - Unreleased
 1. Add items by sending a photo using OpenAI vision to detect items automatically.
 2. Items show green checkmarks when the entire list is checked off.
-3. Checkbox icons indicate item status and trashcan icons appear in deletion mode.
+3. Checkbox icons indicate item status in the list.
+4. Deletion mode highlights selections with red crosses, shows empty squares for
+   unselected items, and uses a trashcan icon to finish.
 
 
 ## [0.1.0] - 2025-06-07

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -64,9 +64,9 @@ pub fn format_delete_list(
 
     for item in items {
         let button_text = if selected.contains(&item.id) {
-            format!("🗑️ {}", item.text)
-        } else {
             format!("❌ {}", item.text)
+        } else {
+            format!("⬜ {}", item.text)
         };
         let callback_data = format!("delete_{}", item.id);
         keyboard_buttons.push(vec![InlineKeyboardButton::callback(

--- a/tests/formatting.rs
+++ b/tests/formatting.rs
@@ -61,7 +61,7 @@ fn test_format_delete_list() {
         .iter()
         .map(|row| row[0].text.as_str())
         .collect();
-    assert_eq!(labels, vec!["🗑️ Apples", "❌ Milk", "🗑️ Done Deleting"]);
+    assert_eq!(labels, vec!["❌ Apples", "⬜ Milk", "🗑️ Done Deleting"]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- use red cross for checked items, square for unchecked, trashcan for completion
- update formatting test expectations
- document new icons in changelog

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`


------
https://chatgpt.com/codex/tasks/task_e_6844b5c74048832dbe7299e9af920663