### PR TITLE
Move text parsing helpers

### DIFF
--- a/src/ai/common.rs
+++ b/src/ai/common.rs
@@ -64,6 +64,6 @@ pub async fn request_items(
     Ok(items_json
         .items
         .into_iter()
-        .filter_map(|s| crate::handlers::parse_item_line(&s))
+        .filter_map(|s| crate::text_utils::parse_item_line(&s))
         .collect())
 }

--- a/src/ai/stt.rs
+++ b/src/ai/stt.rs
@@ -82,17 +82,17 @@ pub async fn transcribe_audio_test(
 /// Split a transcription string from speech-to-text into individual items.
 ///
 /// The text is split on commas, newlines and the word "and". Each segment is
-/// then cleaned via [`crate::handlers::parse_item_line`]. Empty segments are
+/// then cleaned via [`crate::text_utils::parse_item_line`]. Empty segments are
 /// ignored.
 /// Split a text string into individual items.
 ///
 /// The input is split on commas, newlines and the word "and". Each segment is
-/// then cleaned via [`crate::handlers::parse_item_line`]. Empty segments are
+/// then cleaned via [`crate::text_utils::parse_item_line`]. Empty segments are
 /// ignored.
 pub fn parse_items(text: &str) -> Vec<String> {
     text.split([',', '\n'])
         .flat_map(|seg| seg.split(" and "))
-        .filter_map(crate::handlers::parse_item_line)
+        .filter_map(crate::text_utils::parse_item_line)
         .collect()
 }
 
@@ -106,7 +106,7 @@ use crate::ai::common::{request_items, OPENAI_CHAT_URL};
 /// Use the OpenAI Chat API to parse items from arbitrary text.
 ///
 /// The model is instructed to return a JSON object with an `items` array. The
-/// returned list is cleaned with [`crate::handlers::parse_item_line`].
+/// returned list is cleaned with [`crate::text_utils::parse_item_line`].
 #[instrument(level = "trace", skip(api_key))]
 pub async fn parse_items_gpt(api_key: &str, text: &str) -> Result<Vec<String>> {
     parse_items_gpt_inner(api_key, text, OPENAI_CHAT_URL).await

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -7,6 +7,7 @@ use teloxide::{
 };
 
 use crate::db::*;
+use crate::text_utils::{capitalize_first, parse_item_line};
 
 pub async fn help(bot: Bot, msg: Message) -> Result<()> {
     bot.send_message(
@@ -89,40 +90,6 @@ pub fn format_plain_list(items: &[Item]) -> String {
         text.push_str(&format!("• {}\n", item.text));
     }
     text
-}
-
-/// Clean a single text line from a user message.
-///
-/// Returns `None` if the line should be ignored (for example it is the
-/// archived list separator or becomes empty after trimming). Otherwise returns
-/// the cleaned line without leading status emojis or whitespace.
-pub fn parse_item_line(line: &str) -> Option<String> {
-    tracing::trace!(?line, "Parsing item line");
-    if line.trim() == "--- Archived List ---" {
-        tracing::trace!("Ignoring archived list separator");
-        return None;
-    }
-
-    let cleaned = line
-        .trim_start_matches(['☑', '✅', '⬜', '🛒', '\u{fe0f}'])
-        .trim();
-
-    if cleaned.is_empty() {
-        tracing::trace!("Line empty after cleaning");
-        None
-    } else {
-        let result = cleaned.to_string();
-        tracing::trace!(?result, "Parsed line");
-        Some(result)
-    }
-}
-
-fn capitalize_first(text: &str) -> String {
-    let mut chars = text.chars();
-    match chars.next() {
-        Some(c) => c.to_uppercase().chain(chars).collect(),
-        None => String::new(),
-    }
 }
 
 use crate::ai::stt::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,10 +7,12 @@ use teloxide::{prelude::*, utils::command::BotCommands};
 pub mod ai;
 mod db;
 mod handlers;
+mod text_utils;
 
 pub use ai::stt::{parse_items, parse_voice_items};
 pub use db::Item;
-pub use handlers::{format_delete_list, format_list, format_plain_list, parse_item_line};
+pub use handlers::{format_delete_list, format_list, format_plain_list};
+pub use text_utils::{capitalize_first, parse_item_line};
 
 use handlers::{
     add_items_from_parsed_text, add_items_from_photo, add_items_from_text, add_items_from_voice,

--- a/src/text_utils.rs
+++ b/src/text_utils.rs
@@ -1,0 +1,35 @@
+use tracing::trace;
+
+/// Clean a single text line from a user message.
+///
+/// Returns `None` if the line should be ignored (for example it is the
+/// archived list separator or becomes empty after trimming). Otherwise returns
+/// the cleaned line without leading status emojis or whitespace.
+pub fn parse_item_line(line: &str) -> Option<String> {
+    trace!(?line, "Parsing item line");
+    if line.trim() == "--- Archived List ---" {
+        trace!("Ignoring archived list separator");
+        return None;
+    }
+
+    let cleaned = line
+        .trim_start_matches(['☑', '✅', '⬜', '🛒', '\u{fe0f}'])
+        .trim();
+
+    if cleaned.is_empty() {
+        trace!("Line empty after cleaning");
+        None
+    } else {
+        let result = cleaned.to_string();
+        trace!(?result, "Parsed line");
+        Some(result)
+    }
+}
+
+pub fn capitalize_first(text: &str) -> String {
+    let mut chars = text.chars();
+    match chars.next() {
+        Some(c) => c.to_uppercase().chain(chars).collect(),
+        None => String::new(),
+    }
+}


### PR DESCRIPTION
## Summary
- move `parse_item_line` and `capitalize_first` into new `text_utils` module
- update imports and re-exports
- update docs

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`


------
https://chatgpt.com/codex/tasks/task_e_6844bb42b314832d875cdf4b8623b01e