### PR TITLE
Move GPT helpers to separate module

### DIFF
--- a/src/ai.rs
+++ b/src/ai.rs
@@ -1,3 +1,4 @@
 pub mod common;
+pub mod gpt;
 pub mod stt;
 pub mod vision;

--- a/src/ai/common.rs
+++ b/src/ai/common.rs
@@ -64,6 +64,6 @@ pub async fn request_items(
     Ok(items_json
         .items
         .into_iter()
-        .filter_map(|s| crate::handlers::parse_item_line(&s))
+        .filter_map(|s| crate::text_utils::parse_item_line(&s))
         .collect())
 }

--- a/src/ai/gpt.rs
+++ b/src/ai/gpt.rs
@@ -1,0 +1,52 @@
+use crate::ai::common::{request_items, OPENAI_CHAT_URL};
+use anyhow::Result;
+use tracing::instrument;
+
+/// Use the OpenAI Chat API to parse items from arbitrary text.
+///
+/// The model is instructed to return a JSON object with an `items` array. The
+/// returned list is cleaned with [`crate::text_utils::parse_item_line`].
+#[instrument(level = "trace", skip(api_key))]
+pub async fn parse_items_gpt(api_key: &str, text: &str) -> Result<Vec<String>> {
+    parse_items_gpt_inner(api_key, text, OPENAI_CHAT_URL).await
+}
+
+/// Legacy wrapper for [`parse_items_gpt`] used by voice message handling.
+#[instrument(level = "trace", skip(api_key))]
+pub async fn parse_voice_items_gpt(api_key: &str, text: &str) -> Result<Vec<String>> {
+    parse_items_gpt(api_key, text).await
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+#[instrument(level = "trace", skip(api_key))]
+pub async fn parse_items_gpt_inner(api_key: &str, text: &str, url: &str) -> Result<Vec<String>> {
+    let body = serde_json::json!({
+        "model": "gpt-3.5-turbo",
+        "response_format": { "type": "json_object" },
+        "messages": [
+            {
+                "role": "system",
+                "content": "Extract the items from the user's text. Respond with a JSON object like {\"items\": [\"apples\"]}.",
+            },
+            { "role": "user", "content": text },
+        ]
+    });
+
+    request_items(api_key, &body, url).await
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+#[instrument(level = "trace", skip(api_key))]
+pub async fn parse_items_gpt_test(api_key: &str, text: &str, url: &str) -> Result<Vec<String>> {
+    parse_items_gpt_inner(api_key, text, url).await
+}
+
+/// Legacy wrapper for [`parse_items_gpt_test`].
+#[instrument(level = "trace", skip(api_key))]
+pub async fn parse_voice_items_gpt_test(
+    api_key: &str,
+    text: &str,
+    url: &str,
+) -> Result<Vec<String>> {
+    parse_items_gpt_test(api_key, text, url).await
+}

--- a/src/ai/stt.rs
+++ b/src/ai/stt.rs
@@ -82,72 +82,21 @@ pub async fn transcribe_audio_test(
 /// Split a transcription string from speech-to-text into individual items.
 ///
 /// The text is split on commas, newlines and the word "and". Each segment is
-/// then cleaned via [`crate::handlers::parse_item_line`]. Empty segments are
+/// then cleaned via [`crate::text_utils::parse_item_line`]. Empty segments are
 /// ignored.
 /// Split a text string into individual items.
 ///
 /// The input is split on commas, newlines and the word "and". Each segment is
-/// then cleaned via [`crate::handlers::parse_item_line`]. Empty segments are
+/// then cleaned via [`crate::text_utils::parse_item_line`]. Empty segments are
 /// ignored.
 pub fn parse_items(text: &str) -> Vec<String> {
     text.split([',', '\n'])
         .flat_map(|seg| seg.split(" and "))
-        .filter_map(crate::handlers::parse_item_line)
+        .filter_map(crate::text_utils::parse_item_line)
         .collect()
 }
 
 /// Legacy wrapper for [`parse_items`] used by older code paths.
 pub fn parse_voice_items(text: &str) -> Vec<String> {
     parse_items(text)
-}
-
-use crate::ai::common::{request_items, OPENAI_CHAT_URL};
-
-/// Use the OpenAI Chat API to parse items from arbitrary text.
-///
-/// The model is instructed to return a JSON object with an `items` array. The
-/// returned list is cleaned with [`crate::handlers::parse_item_line`].
-#[instrument(level = "trace", skip(api_key))]
-pub async fn parse_items_gpt(api_key: &str, text: &str) -> Result<Vec<String>> {
-    parse_items_gpt_inner(api_key, text, OPENAI_CHAT_URL).await
-}
-
-/// Legacy wrapper for [`parse_items_gpt`] used by voice message handling.
-#[instrument(level = "trace", skip(api_key))]
-pub async fn parse_voice_items_gpt(api_key: &str, text: &str) -> Result<Vec<String>> {
-    parse_items_gpt(api_key, text).await
-}
-
-#[cfg_attr(not(test), allow(dead_code))]
-#[instrument(level = "trace", skip(api_key))]
-pub async fn parse_items_gpt_inner(api_key: &str, text: &str, url: &str) -> Result<Vec<String>> {
-    let body = serde_json::json!({
-        "model": "gpt-3.5-turbo",
-        "response_format": { "type": "json_object" },
-        "messages": [
-            {
-                "role": "system",
-                "content": "Extract the items from the user's text. Respond with a JSON object like {\"items\": [\"apples\"]}.",
-            },
-            { "role": "user", "content": text },
-        ]
-    });
-
-    request_items(api_key, &body, url).await
-}
-
-#[cfg_attr(not(test), allow(dead_code))]
-#[instrument(level = "trace", skip(api_key))]
-pub async fn parse_items_gpt_test(api_key: &str, text: &str, url: &str) -> Result<Vec<String>> {
-    parse_items_gpt_inner(api_key, text, url).await
-}
-
-/// Legacy wrapper for [`parse_items_gpt_test`].
-#[instrument(level = "trace", skip(api_key))]
-pub async fn parse_voice_items_gpt_test(
-    api_key: &str,
-    text: &str,
-    url: &str,
-) -> Result<Vec<String>> {
-    parse_items_gpt_test(api_key, text, url).await
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -46,6 +46,18 @@ fn join_selected(set: &HashSet<i64>) -> String {
         .join(",")
 }
 
+pub fn prepare_sqlite_url(url: &str) -> String {
+    if url.starts_with("sqlite:") && !url.contains("mode=") && !url.contains(":memory:") {
+        if url.contains('?') {
+            format!("{url}&mode=rwc")
+        } else {
+            format!("{url}?mode=rwc")
+        }
+    } else {
+        url.to_string()
+    }
+}
+
 pub async fn connect_db(db_url: &str) -> Result<Pool<Sqlite>> {
     tracing::debug!(db_url = %db_url, "Connecting to database");
     Ok(SqlitePoolOptions::new()
@@ -275,6 +287,35 @@ mod tests {
         let joined = join_selected(&original);
         let parsed = parse_selected(&joined);
         assert_eq!(original, parsed);
+    }
+
+    #[test]
+    fn prepare_sqlite_url_basic() {
+        assert_eq!(
+            prepare_sqlite_url("sqlite:items.db"),
+            "sqlite:items.db?mode=rwc"
+        );
+    }
+
+    #[test]
+    fn prepare_sqlite_url_with_query() {
+        assert_eq!(
+            prepare_sqlite_url("sqlite:items.db?cache=shared"),
+            "sqlite:items.db?cache=shared&mode=rwc"
+        );
+    }
+
+    #[test]
+    fn prepare_sqlite_url_existing_mode() {
+        assert_eq!(
+            prepare_sqlite_url("sqlite:items.db?mode=ro"),
+            "sqlite:items.db?mode=ro"
+        );
+    }
+
+    #[test]
+    fn prepare_sqlite_url_memory() {
+        assert_eq!(prepare_sqlite_url("sqlite::memory:"), "sqlite::memory:");
     }
 
     proptest! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,27 +7,19 @@ use teloxide::{prelude::*, utils::command::BotCommands};
 pub mod ai;
 mod db;
 mod handlers;
+mod text_utils;
 
+pub use ai::gpt::{parse_items_gpt, parse_voice_items_gpt};
 pub use ai::stt::{parse_items, parse_voice_items};
 pub use db::Item;
-pub use handlers::{format_delete_list, format_list, format_plain_list, parse_item_line};
+pub use handlers::{format_delete_list, format_list, format_plain_list};
+pub use text_utils::{capitalize_first, parse_item_line};
 
 use handlers::{
     add_items_from_parsed_text, add_items_from_photo, add_items_from_text, add_items_from_voice,
     archive, callback_handler, enter_delete_mode, help, nuke_list, send_list, share_list,
 };
 
-fn prepare_sqlite_url(url: &str) -> String {
-    if url.starts_with("sqlite:") && !url.contains("mode=") && !url.contains(":memory:") {
-        if url.contains('?') {
-            format!("{url}&mode=rwc")
-        } else {
-            format!("{url}?mode=rwc")
-        }
-    } else {
-        url.to_string()
-    }
-}
 // ──────────────────────────────────────────────────────────────
 // Main application setup
 // ──────────────────────────────────────────────────────────────
@@ -57,7 +49,7 @@ pub async fn run() -> Result<()> {
     // --- SQLite Pool ---
     // Read the database URL from the environment, with a fallback for local dev.
     let db_url = env::var("DB_URL").unwrap_or_else(|_| "sqlite:shopping.db".to_string());
-    let db_url = prepare_sqlite_url(&db_url);
+    let db_url = db::prepare_sqlite_url(&db_url);
 
     tracing::info!("Connecting to database at: {}", &db_url);
 
@@ -243,34 +235,5 @@ mod tests {
         assert!(get_last_list_message_id(&db, chat).await?.is_none());
 
         Ok(())
-    }
-
-    #[test]
-    fn prepare_sqlite_url_basic() {
-        assert_eq!(
-            prepare_sqlite_url("sqlite:items.db"),
-            "sqlite:items.db?mode=rwc"
-        );
-    }
-
-    #[test]
-    fn prepare_sqlite_url_with_query() {
-        assert_eq!(
-            prepare_sqlite_url("sqlite:items.db?cache=shared"),
-            "sqlite:items.db?cache=shared&mode=rwc"
-        );
-    }
-
-    #[test]
-    fn prepare_sqlite_url_existing_mode() {
-        assert_eq!(
-            prepare_sqlite_url("sqlite:items.db?mode=ro"),
-            "sqlite:items.db?mode=ro"
-        );
-    }
-
-    #[test]
-    fn prepare_sqlite_url_memory() {
-        assert_eq!(prepare_sqlite_url("sqlite::memory:"), "sqlite::memory:");
     }
 }

--- a/src/text_utils.rs
+++ b/src/text_utils.rs
@@ -1,0 +1,35 @@
+use tracing::trace;
+
+/// Clean a single text line from a user message.
+///
+/// Returns `None` if the line should be ignored (for example it is the
+/// archived list separator or becomes empty after trimming). Otherwise returns
+/// the cleaned line without leading status emojis or whitespace.
+pub fn parse_item_line(line: &str) -> Option<String> {
+    trace!(?line, "Parsing item line");
+    if line.trim() == "--- Archived List ---" {
+        trace!("Ignoring archived list separator");
+        return None;
+    }
+
+    let cleaned = line
+        .trim_start_matches(['☑', '✅', '⬜', '🛒', '\u{fe0f}'])
+        .trim();
+
+    if cleaned.is_empty() {
+        trace!("Line empty after cleaning");
+        None
+    } else {
+        let result = cleaned.to_string();
+        trace!(?result, "Parsed line");
+        Some(result)
+    }
+}
+
+pub fn capitalize_first(text: &str) -> String {
+    let mut chars = text.chars();
+    match chars.next() {
+        Some(c) => c.to_uppercase().chain(chars).collect(),
+        None => String::new(),
+    }
+}


### PR DESCRIPTION
## Summary
- add new `ai::gpt` module for GPT-based item parsing helpers
- update imports to use `ai::gpt`
- expose GPT helpers from crate root
- merge latest changes from `main`

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`


------
https://chatgpt.com/codex/tasks/task_e_6844bb45a1dc832d978c024e4b8a35ad