### PR TITLE
Update RUST_LOG configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 3. Checkbox icons indicate item status in the list.
 4. Deletion mode highlights selections with red crosses, shows empty squares for
    unselected items, and uses a trashcan icon to finish.
+5. Reduced noisy HTTP logs by setting the `hyper` log level to info in `fly.toml`.
 
 
 ## [0.1.0] - 2025-06-07

--- a/fly.toml
+++ b/fly.toml
@@ -6,7 +6,7 @@ dockerfile = 'Dockerfile'
 image_tag = "latest"
 
 [env]
-RUST_LOG = 'trace'
+RUST_LOG = 'trace,hyper=info'
 DB_URL = 'sqlite:///data/shopping.db'
 OPENAI_STT_MODEL = 'gpt-4o-transcribe'
 


### PR DESCRIPTION
## Summary
- set `hyper` to `info` logging level in Fly configuration
- note the new quieter log level in the changelog

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`


------
https://chatgpt.com/codex/tasks/task_e_6844cf95b260832dbcdd33008de062d9