### PR TITLE
Release 0.2.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,8 @@
   (proptests) when feasible.
 - Avoid global state. Persist temporary data such as deletion selections and any notice messages in the database.
 - Keep the `migrations/` directory up to date whenever the database schema changes so that embedded migrations remain in sync.
-- Update `CHANGELOG.md` with a new entry for any user-visible change. Keep pending changes at the top as a numbered list. When the project version is bumped, insert a `## [version] - <date>` header above that list and start a new numbered list for the next release.
+- Update `CHANGELOG.md` with a new entry for any user-visible change. Keep pending changes under a `## Unreleased` section as a numbered list. When the project version is bumped, add a `## [version] - <date>` heading below `Unreleased` and continue the next list under `Unreleased`.
+- When updating versions in manifests, increment the patch version.
 - This is a generic list bot. Avoid hardcoding references to "groceries" in prompts or logs. Use generic "items" wording instead.
 - Follow the modern Rust module layout: define a `name.rs` file alongside a
   `name/` directory for submodules instead of using `mod.rs`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.2.0] - Unreleased
+## Unreleased
+
+## [0.2.0] - 2025-06-08
 1. Add items by sending a photo using OpenAI vision to detect items automatically.
 2. Items show green checkmarks when the entire list is checked off.
 3. Checkbox icons indicate item status in the list.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2009,7 +2009,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shopbot"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shopbot"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## Summary
- clarify changelog guidelines in `AGENTS.md`
- start an `Unreleased` section in `CHANGELOG.md`
- bump crate version to 0.2.1

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`


------
https://chatgpt.com/codex/tasks/task_e_6845738ad778832d9abb1c79e870de9a