### PR TITLE
Improve CI performance with caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,16 @@ jobs:
           toolchain: stable
           override: true
           components: rustfmt, clippy
+      - name: Cache cargo
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
       - name: Cargo fmt
         run: cargo fmt --all -- --check
       - name: Cargo clippy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+1. GitHub Actions caches cargo dependencies for faster builds.
 
 ## [0.2.0] - 2025-06-08
 1. Add items by sending a photo using OpenAI vision to detect items automatically.


### PR DESCRIPTION
## Summary
- cache cargo build artifacts in CI
- document the caching improvement in the changelog

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`

------
https://chatgpt.com/codex/tasks/task_e_684583be7b3c832db9c95659a11ada4a