### PR TITLE
Fix system info test for release builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+1. `/info` command shows commit hash and release version or how many commits the build is ahead of the latest release
 
 ## [0.2.0] - 2025-06-08
 1. Add items by sending a photo using OpenAI vision to detect items automatically.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,6 +660,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "git-version"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad568aa3db0fcbc81f2f116137f263d7304f512a1209b35b85150d3ef88ad19"
+dependencies = [
+ "git-version-macro",
+]
+
+[[package]]
+name = "git-version-macro"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2015,6 +2035,7 @@ dependencies = [
  "base64 0.21.7",
  "dotenvy",
  "futures-util",
+ "git-version",
  "proptest",
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "shopbot"
 version = "0.2.1"
 edition = "2021"
+build = "build.rs"
 
 [dependencies]
 anyhow = "1.0"
@@ -16,6 +17,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 futures-util = "0.3"
 base64 = "0.21"
+git-version = "0.3"
 
 [dev-dependencies]
 proptest = "1.6"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Send any message to the bot. Every non-empty line becomes an item. If you send a
 - `/share` – send the list as plain text
 - `/nuke` – wipe the list completely
 - `/parse` – let GPT parse this message into items
+- `/info` – show commit hash and whether the build is on a release or how far it is ahead of the latest release
 
 ## Installation
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,40 @@
+use std::process::Command;
+
+fn main() {
+    // Expose HEAD's tag if it's a release commit.
+    let tag = Command::new("git")
+        .args(["describe", "--tags", "--exact-match"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_default();
+
+    println!("cargo:rustc-env=RELEASE_VERSION={}", tag);
+
+    // Always expose the latest release tag for dev builds.
+    let latest = Command::new("git")
+        .args(["describe", "--tags", "--abbrev=0"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_default();
+
+    println!("cargo:rustc-env=LATEST_TAG={}", latest);
+
+    // Count commits since the latest tag so we can display how far ahead we are.
+    let ahead = if latest.is_empty() {
+        String::new()
+    } else {
+        Command::new("git")
+            .args(["rev-list", "--count", &format!("{}..HEAD", latest)])
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+            .unwrap_or_default()
+    };
+
+    println!("cargo:rustc-env=COMMITS_AHEAD={}", ahead);
+}

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,10 +1,12 @@
 pub mod delete;
+pub mod info;
 pub mod list;
 pub mod photo;
 pub mod text;
 pub mod voice;
 
 pub use delete::{callback_handler, enter_delete_mode, format_delete_list};
+pub use info::show_system_info;
 pub use list::{archive, format_list, format_plain_list, nuke_list, send_list, share_list};
 pub use photo::add_items_from_photo;
 pub use text::{add_items_from_parsed_text, add_items_from_text, help};

--- a/src/handlers/info.rs
+++ b/src/handlers/info.rs
@@ -1,0 +1,10 @@
+use anyhow::Result;
+use teloxide::prelude::*;
+
+use crate::system_info::get_system_info;
+
+pub async fn show_system_info(bot: Bot, msg: Message) -> Result<()> {
+    tracing::debug!(chat_id = msg.chat.id.0, "Showing system info");
+    bot.send_message(msg.chat.id, get_system_info()).await?;
+    Ok(())
+}

--- a/src/handlers/text.rs
+++ b/src/handlers/text.rs
@@ -20,7 +20,8 @@ pub async fn help(bot: Bot, msg: Message) -> Result<()> {
              /delete - Show a temporary panel to delete items from the list.\n\
              /share - Send the list as plain text for copying.\n\
              /nuke - Completely delete the current list.\n\
-             /parse - Parse this message into items via GPT.",
+             /parse - Parse this message into items via GPT.\n\
+             /info - Show system information.",
     )
     .parse_mode(teloxide::types::ParseMode::Html)
     .await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,17 +7,20 @@ use teloxide::{prelude::*, utils::command::BotCommands};
 pub mod ai;
 mod db;
 mod handlers;
+mod system_info;
 mod text_utils;
 
 pub use ai::gpt::{parse_items_gpt, parse_voice_items_gpt};
 pub use ai::stt::{parse_items, parse_voice_items};
 pub use db::Item;
 pub use handlers::{format_delete_list, format_list, format_plain_list};
+pub use system_info::get_system_info;
 pub use text_utils::{capitalize_first, parse_item_line};
 
 use handlers::{
     add_items_from_parsed_text, add_items_from_photo, add_items_from_text, add_items_from_voice,
     archive, callback_handler, enter_delete_mode, help, nuke_list, send_list, share_list,
+    show_system_info,
 };
 
 // ──────────────────────────────────────────────────────────────
@@ -85,6 +88,8 @@ pub async fn run() -> Result<()> {
         Nuke,
         #[command(description = "parse items from the given text using GPT.")]
         Parse,
+        #[command(description = "show system information.")]
+        Info,
     }
 
     // --- Handler Setup ---
@@ -118,6 +123,7 @@ pub async fn run() -> Result<()> {
                             Command::Parse => {
                                 add_items_from_parsed_text(bot, msg, db, stt_config).await?
                             }
+                            Command::Info => show_system_info(bot, msg).await?,
                         }
                         Ok(())
                     },

--- a/src/system_info.rs
+++ b/src/system_info.rs
@@ -41,6 +41,6 @@ mod tests {
         let info = get_system_info();
         assert!(info.contains(expected));
         assert!(info.contains("Dev build") || info.contains("Release build"));
-        assert!(info.contains("release") || info.contains("commits ahead of"));
+        assert!(info.contains("release") || info.contains("development"));
     }
 }

--- a/src/system_info.rs
+++ b/src/system_info.rs
@@ -1,0 +1,46 @@
+use git_version::git_version;
+
+// include -modified if the working tree has uncommitted changes
+const COMMIT: &str = git_version!(args = ["--abbrev=10", "--always", "--dirty=-modified"]);
+
+pub fn get_system_info() -> String {
+    let profile = if cfg!(debug_assertions) {
+        "Dev"
+    } else {
+        "Release"
+    };
+
+    let latest = option_env!("LATEST_TAG").unwrap_or("");
+    let ahead = option_env!("COMMITS_AHEAD").unwrap_or("");
+    let version = match option_env!("RELEASE_VERSION") {
+        Some(tag) if !tag.is_empty() => format!("release {}", tag),
+        _ if !latest.is_empty() && !ahead.is_empty() => {
+            format!("development branch {} commits ahead of {}", ahead, latest)
+        }
+        _ if !latest.is_empty() => format!("development branch ahead of {}", latest),
+        _ => "development".to_string(),
+    };
+
+    format!(
+        "{} - {}\nCommit: {}\n{} build",
+        env!("CARGO_PKG_NAME"),
+        version,
+        COMMIT,
+        profile
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use git_version::git_version;
+
+    #[test]
+    fn test_get_system_info() {
+        let expected = git_version!(args = ["--abbrev=10", "--always", "--dirty=-modified"]);
+        let info = get_system_info();
+        assert!(info.contains(expected));
+        assert!(info.contains("Dev build") || info.contains("Release build"));
+        assert!(info.contains("release") || info.contains("commits ahead of"));
+    }
+}

--- a/tests/system_info.rs
+++ b/tests/system_info.rs
@@ -7,5 +7,5 @@ fn test_system_info_contains_commit_and_profile() {
     let info = get_system_info();
     assert!(info.contains(expected));
     assert!(info.contains("Dev build") || info.contains("Release build"));
-    assert!(info.contains("release") || info.contains("commits ahead of"));
+    assert!(info.contains("release") || info.contains("development"));
 }

--- a/tests/system_info.rs
+++ b/tests/system_info.rs
@@ -1,0 +1,11 @@
+use git_version::git_version;
+use shopbot::get_system_info;
+
+#[test]
+fn test_system_info_contains_commit_and_profile() {
+    let expected = git_version!(args = ["--abbrev=10", "--always", "--dirty=-modified"]);
+    let info = get_system_info();
+    assert!(info.contains(expected));
+    assert!(info.contains("Dev build") || info.contains("Release build"));
+    assert!(info.contains("release") || info.contains("commits ahead of"));
+}


### PR DESCRIPTION
## Summary
- relax the system information tests to work on release commits

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`


------
https://chatgpt.com/codex/tasks/task_e_68458834ba0c832dbf4eb08918e5196e