### PR TITLE
Update release commit policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@
 - Avoid global state. Persist temporary data such as deletion selections and any notice messages in the database.
 - Keep the `migrations/` directory up to date whenever the database schema changes so that embedded migrations remain in sync.
 - Update `CHANGELOG.md` only for user-visible changes. Internal CI and tooling updates should not be listed. Keep pending changes under a `## Unreleased` section as a numbered list. When the project version is bumped, add a `## [version] - <date>` heading below `Unreleased` and continue the next list under `Unreleased`.
+- Release commits may update the manifest version to match the release's semver. After the release PR is merged, a maintainer tags that commit. The next PR should then bump the version to the next patch level and start a fresh `## Unreleased` section in `CHANGELOG.md`.
 - When updating versions in manifests, increment the patch version.
 - This is a generic list bot. Avoid hardcoding references to "groceries" in prompts or logs. Use generic "items" wording instead.
 - Follow the modern Rust module layout: define a `name.rs` file alongside a


### PR DESCRIPTION
## Summary
- clarify instructions for how to bump manifest versions after a release

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`


------
https://chatgpt.com/codex/tasks/task_e_68459279f328832db5def06d47d7696b