### PR TITLE
Fix Docker build by copying .git

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,4 +3,3 @@ target
 fly.toml
 .dockerignore
 .gitignore
-.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN cargo chef prepare --recipe-path recipe.json
 FROM rust:1.87-slim AS cacher
 WORKDIR /app
 # Install system dependencies required for building crates like `openssl-sys`
-RUN apt-get update -qq && apt-get install -y --no-install-recommends pkg-config libssl-dev
+RUN apt-get update -qq && apt-get install -y --no-install-recommends git pkg-config libssl-dev
 RUN cargo install cargo-chef
 COPY --from=planner /app/recipe.json recipe.json
 # Build dependencies
@@ -25,7 +25,7 @@ RUN cargo chef cook --release --recipe-path recipe.json
 FROM rust:1.87-slim AS builder
 WORKDIR /app
 # Install system dependencies required for the final link
-RUN apt-get update -qq && apt-get install -y --no-install-recommends pkg-config libssl-dev
+RUN apt-get update -qq && apt-get install -y --no-install-recommends git pkg-config libssl-dev
 COPY . .
 # Copy over the pre-built dependencies from the cacher stage
 COPY --from=cacher /app/target target


### PR DESCRIPTION
## Summary
- include the repository's git history when building the Docker image so `git_version` works

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`


------
https://chatgpt.com/codex/tasks/task_e_68459fb978fc832da59294ad6edd2ef8