### PR TITLE
Fix git dirty state in builder

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,3 @@
 **/.env
 target
-fly.toml
 .dockerignore
-.gitignore


### PR DESCRIPTION
## Summary
- keep `fly.toml` and `.gitignore` when copying the repo during Docker build so git doesn't report a dirty tree

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`


------
https://chatgpt.com/codex/tasks/task_e_6845b0395cac832d989a294e7eaa453b