### PR TITLE
Add voice deletion via GPT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 1. `/info` command shows commit hash and release version or how many commits the build is ahead of the latest release
+2. Remove items via voice commands like "delete milk". The bot replies with a copyable list of the deleted entries.
 
 ## [0.2.0] - 2025-06-08
 1. Add items by sending a photo using OpenAI vision to detect items automatically.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Vibe Grocery Bot is a small Telegram bot for managing a shared shopping list. Ea
 
 ## Usage
 
-Send any message to the bot. Every non-empty line becomes an item. If you send a voice or photo message and an OpenAI API key is configured, the bot will try to recognize items automatically. The bot responds with a list message containing checkbox buttons so you can mark things bought. The main commands are:
+Send any message to the bot. Every non-empty line becomes an item. If you send a voice or photo message and an OpenAI API key is configured, the bot will try to recognize items automatically. A voice command like "delete milk and bread" removes those entries and the bot confirms with a list starting with a trashcan emoji. The bot responds with a list message containing checkbox buttons so you can mark things bought. The main commands are:
 
 - `/list` – show the list again
 - `/archive` – archive the current list and start a new one

--- a/src/ai/stt.rs
+++ b/src/ai/stt.rs
@@ -10,9 +10,9 @@ pub struct SttConfig {
 }
 
 /// Default instructions passed to GPT-based transcription models.
-/// The prompt also asks the model to keep spoken numbers intact so they aren't
-/// discarded during transcription.
-pub const DEFAULT_PROMPT: &str = "List the items mentioned, separated by commas or the word 'and'. Preserve numbers exactly as spoken.";
+/// The prompt also asks the model to keep spoken numbers intact and preserve
+/// verbs so commands like "delete" are not dropped during transcription.
+pub const DEFAULT_PROMPT: &str = "Transcribe the user's request about the list. Keep numbers and verbs like 'add' or 'delete' exactly as spoken.";
 
 #[derive(Deserialize)]
 struct TranscriptionResponse {

--- a/src/text_utils.rs
+++ b/src/text_utils.rs
@@ -13,7 +13,7 @@ pub fn parse_item_line(line: &str) -> Option<String> {
     }
 
     let cleaned = line
-        .trim_start_matches(['☑', '✅', '⬜', '🛒', '\u{fe0f}'])
+        .trim_start_matches(['☑', '✅', '⬜', '🛒', '•', '\u{fe0f}'])
         .trim();
 
     if cleaned.is_empty() {

--- a/tests/text_parsing.rs
+++ b/tests/text_parsing.rs
@@ -13,4 +13,6 @@ fn test_parse_item_line() {
     assert_eq!(parse_item_line("--- Archived List ---"), None);
     // Empty line when only an emoji and spaces
     assert_eq!(parse_item_line("☑️   "), None);
+    // Bullet prefix
+    assert_eq!(parse_item_line("• Milk"), Some("Milk".to_string()));
 }

--- a/tests/voice_command.rs
+++ b/tests/voice_command.rs
@@ -1,0 +1,51 @@
+use shopbot::ai::gpt::{interpret_voice_command_test, VoiceCommand};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn test_voice_command_delete() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            r#"{"choices":[{"message":{"content":"{\"delete\":[\"Milk\"]}"}}]}"#,
+            "application/json",
+        ))
+        .mount(&server)
+        .await;
+
+    let url = format!("{}/v1/chat/completions", server.uri());
+    let res = interpret_voice_command_test(
+        "k",
+        "delete milk",
+        &["Milk".to_string(), "Bread".to_string()],
+        &url,
+    )
+    .await
+    .unwrap();
+    assert_eq!(res, VoiceCommand::Delete(vec!["Milk".to_string()]));
+}
+
+#[tokio::test]
+async fn test_voice_command_add() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            r#"{"choices":[{"message":{"content":"{\"add\":[\"Apples\"]}"}}]}"#,
+            "application/json",
+        ))
+        .mount(&server)
+        .await;
+
+    let url = format!("{}/v1/chat/completions", server.uri());
+    let res = interpret_voice_command_test(
+        "k",
+        "apples",
+        &["Milk".to_string(), "Bread".to_string()],
+        &url,
+    )
+    .await
+    .unwrap();
+    assert_eq!(res, VoiceCommand::Add(vec!["Apples".to_string()]));
+}


### PR DESCRIPTION
## Summary
- update STT prompt to keep verbs
- parse voice commands via GPT and support deleting items
- send copyable confirmation when items are removed
- trim bullet prefix when parsing lines
- document voice deletion
- add tests for new behaviour

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`

------
https://chatgpt.com/codex/tasks/task_e_68459c6e5c1c832d881f5baffa6d7822