### PR TITLE
Improve GPT instructions for voice requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 1. `/info` command shows commit hash and release version or how many commits the build is ahead of the latest release
 2. Remove items via voice commands like "delete milk". The bot replies with a copyable list of the deleted entries.
+3. Voice requests prefer nominative item names and numeric quantities when interpreting additions.
 
 ## [0.2.0] - 2025-06-08
 1. Add items by sending a photo using OpenAI vision to detect items automatically.

--- a/src/ai/gpt.rs
+++ b/src/ai/gpt.rs
@@ -26,7 +26,7 @@ pub async fn parse_items_gpt_inner(api_key: &str, text: &str, url: &str) -> Resu
         "messages": [
             {
                 "role": "system",
-                "content": "Extract the items from the user's text. Preserve numbers exactly as provided, such as '1 milk'. Respond with a JSON object like {\"items\": [\"1 milk\"]}.",
+                "content": "Extract the items from the user's text. Use the nominative form for nouns when it does not change the meaning. Prefer digits for quantities like '42 eggs'. Respond with a JSON object like {\"items\": [\"1 milk\"]}",
             },
             { "role": "user", "content": text },
         ]
@@ -87,7 +87,7 @@ pub async fn interpret_voice_command_inner(
     };
 
     let prompt = format!(
-        "You manage a list of items. {list_text} Decide whether the user's request adds items or removes items from the list. Return a JSON object like {{\"add\":[...]}} or {{\"delete\":[...]}}. For deletions, only include items exactly as they appear in the list. If unsure, treat it as an addition request."
+        "You manage a list of items. {list_text} Decide whether the user's request adds items or removes items from the list. Return a JSON object like {{\"add\":[...]}} or {{\"delete\":[...]}}. For deletions, only include items exactly as they appear in the list. If unsure, treat it as an addition request. Use nominative forms for item names when possible and prefer digits for quantities."
     );
 
     let body = serde_json::json!({

--- a/src/ai/stt.rs
+++ b/src/ai/stt.rs
@@ -10,9 +10,10 @@ pub struct SttConfig {
 }
 
 /// Default instructions passed to GPT-based transcription models.
-/// The prompt also asks the model to keep spoken numbers intact and preserve
-/// verbs so commands like "delete" are not dropped during transcription.
-pub const DEFAULT_PROMPT: &str = "Transcribe the user's request about the list. Keep numbers and verbs like 'add' or 'delete' exactly as spoken.";
+/// The prompt also asks the model to keep verbs intact so commands like
+/// "delete" are not dropped during transcription. Quantities should be
+/// written using digits when possible so "сорок две" becomes "42".
+pub const DEFAULT_PROMPT: &str = "Transcribe the user's request about the list. Keep verbs like 'add' or 'delete' exactly as spoken. Use digits for quantities whenever possible.";
 
 #[derive(Deserialize)]
 struct TranscriptionResponse {


### PR DESCRIPTION
## Summary
- tweak transcription prompt to favor digits
- request nominative forms and numeric quantities from GPT
- document change in CHANGELOG

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`


------
https://chatgpt.com/codex/tasks/task_e_6845d64621c4832d97797be3d4cb7c06