### PR TITLE
Improve voice deletion matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 1. `/info` command shows commit hash and release version or how many commits the build is ahead of the latest release
 2. Remove items via voice commands like "delete milk". The bot replies with a copyable list of the deleted entries.
 3. Voice requests prefer nominative item names and numeric quantities when interpreting additions.
+4. Voice command prompt now ensures deletions return items exactly as listed so numbers aren't dropped.
+5. Voice GPT prompt includes the list in JSON form to reduce misunderstandings.
 
 ## [0.2.0] - 2025-06-08
 1. Add items by sending a photo using OpenAI vision to detect items automatically.

--- a/src/ai/gpt.rs
+++ b/src/ai/gpt.rs
@@ -85,9 +85,10 @@ pub async fn interpret_voice_command_inner(
     } else {
         format!("Current items: {}.", list.join(", "))
     };
+    let list_json = serde_json::to_string(list)?;
 
     let prompt = format!(
-        "You manage a list of items. {list_text} Decide whether the user's request adds items or removes items from the list. Return a JSON object like {{\"add\":[...]}} or {{\"delete\":[...]}}. For deletions, only include items exactly as they appear in the list. If unsure, treat it as an addition request. Use nominative forms for item names when possible and prefer digits for quantities."
+        "You manage a list of items. {list_text} The list as JSON is {list_json}. Decide whether the user's request adds items or removes items from the list. Return a JSON object like {{\"add\":[...]}} or {{\"delete\":[...]}}. For deletions, include each item exactly as it appears in the list, including any leading quantities. If unsure, treat it as an addition request. Use nominative forms for item names when possible and prefer digits for quantities."
     );
 
     let body = serde_json::json!({

--- a/src/handlers/voice.rs
+++ b/src/handlers/voice.rs
@@ -6,7 +6,7 @@ use teloxide::{net::Download, prelude::*};
 use crate::ai::gpt::{interpret_voice_command, VoiceCommand};
 use crate::ai::stt::{parse_voice_items, transcribe_audio, SttConfig, DEFAULT_PROMPT};
 use crate::db::{add_item, delete_item, list_items};
-use crate::text_utils::capitalize_first;
+use crate::text_utils::{capitalize_first, normalize_for_match};
 
 use super::list::send_list;
 
@@ -56,7 +56,11 @@ pub async fn add_items_from_voice(
                 Ok(VoiceCommand::Delete(items)) => {
                     let mut deleted = Vec::new();
                     for item in items {
-                        if let Some(found) = current.iter().find(|i| i.text == item) {
+                        let needle = normalize_for_match(&item);
+                        if let Some(found) = current
+                            .iter()
+                            .find(|i| normalize_for_match(&i.text) == needle)
+                        {
                             delete_item(&db, found.id).await?;
                             deleted.push(found.text.clone());
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ pub use ai::stt::{parse_items, parse_voice_items};
 pub use db::Item;
 pub use handlers::{format_delete_list, format_list, format_plain_list};
 pub use system_info::get_system_info;
-pub use text_utils::{capitalize_first, parse_item_line};
+pub use text_utils::{capitalize_first, normalize_for_match, parse_item_line};
 
 use handlers::{
     add_items_from_parsed_text, add_items_from_photo, add_items_from_text, add_items_from_voice,

--- a/src/text_utils.rs
+++ b/src/text_utils.rs
@@ -38,3 +38,17 @@ pub fn capitalize_first(text: &str) -> String {
         None => String::new(),
     }
 }
+
+/// Normalize an item string for matching operations.
+///
+/// This removes any leading quantity digits and whitespace and
+/// lowercases the rest so lookups are more tolerant to voice command
+/// variations.
+pub fn normalize_for_match(text: &str) -> String {
+    let trimmed = text
+        .trim_start_matches(|c: char| c.is_ascii_digit() || c.is_whitespace())
+        .trim();
+    let result = trimmed.to_lowercase();
+    trace!(original = %text, normalized = %result, "normalized for match");
+    result
+}

--- a/tests/normalization.rs
+++ b/tests/normalization.rs
@@ -1,0 +1,8 @@
+use shopbot::normalize_for_match;
+
+#[test]
+fn test_normalize_for_match() {
+    assert_eq!(normalize_for_match("1 hammer"), "hammer");
+    assert_eq!(normalize_for_match("   42  nails"), "nails");
+    assert_eq!(normalize_for_match("Hammer"), "hammer");
+}


### PR DESCRIPTION
## Summary
- allow fuzzy matching by normalizing quantity prefixes
- use the normalization when removing items via voice commands
- export the new helper and cover it with tests
- refine the GPT prompt so deletions include entire item text
- include the current list in JSON format when sending GPT voice prompts

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`


------
https://chatgpt.com/codex/tasks/task_e_6845e45494ac832d9e9d7974a7f4638d