### PR TITLE
Fix number parsing approach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 3. Voice requests prefer nominative item names and numeric quantities when interpreting additions.
 4. Voice command prompt now ensures deletions return items exactly as listed so numbers aren't dropped.
 5. Voice GPT prompt includes the list in JSON form to reduce misunderstandings.
+6. Empty voice transcriptions are ignored instead of confusing the GPT command
+   parser.
 
 ## [0.2.0] - 2025-06-08
 1. Add items by sending a photo using OpenAI vision to detect items automatically.

--- a/src/ai/gpt.rs
+++ b/src/ai/gpt.rs
@@ -26,7 +26,7 @@ pub async fn parse_items_gpt_inner(api_key: &str, text: &str, url: &str) -> Resu
         "messages": [
             {
                 "role": "system",
-                "content": "Extract the items from the user's text. Use the nominative form for nouns when it does not change the meaning. Prefer digits for quantities like '42 eggs'. Respond with a JSON object like {\"items\": [\"1 milk\"]}",
+                "content": "Extract the items from the user's text. Use the nominative form for nouns when it does not change the meaning. Convert number words to digits so 'три ананаса' becomes '3 ананаса'. Respond with a JSON object like {\"items\": [\"1 milk\"]}",
             },
             { "role": "user", "content": text },
         ]
@@ -88,7 +88,7 @@ pub async fn interpret_voice_command_inner(
     let list_json = serde_json::to_string(list)?;
 
     let prompt = format!(
-        "You manage a list of items. {list_text} The list as JSON is {list_json}. Decide whether the user's request adds items or removes items from the list. Return a JSON object like {{\"add\":[...]}} or {{\"delete\":[...]}}. For deletions, include each item exactly as it appears in the list, including any leading quantities. If unsure, treat it as an addition request. Use nominative forms for item names when possible and prefer digits for quantities."
+        "You manage a list of items. {list_text} The list as JSON is {list_json}. Decide whether the user's request adds items or removes items from the list. Return a JSON object like {{\"add\":[...]}} or {{\"delete\":[...]}}. For deletions, include each item exactly as it appears in the list, including any leading quantities. If unsure, treat it as an addition request. Use nominative forms for item names when possible and convert number words to digits."
     );
 
     let body = serde_json::json!({

--- a/src/ai/stt.rs
+++ b/src/ai/stt.rs
@@ -12,8 +12,9 @@ pub struct SttConfig {
 /// Default instructions passed to GPT-based transcription models.
 /// The prompt also asks the model to keep verbs intact so commands like
 /// "delete" are not dropped during transcription. Quantities should be
-/// written using digits when possible so "сорок две" becomes "42".
-pub const DEFAULT_PROMPT: &str = "Transcribe the user's request about the list. Keep verbs like 'add' or 'delete' exactly as spoken. Use digits for quantities whenever possible.";
+/// written using digits when possible. Convert spelled-out numbers to digits
+/// so phrases like "три ананаса" become "3 ананаса".
+pub const DEFAULT_PROMPT: &str = "Transcribe the user's request about the list. Keep verbs like 'add' or 'delete' exactly as spoken. Use digits for quantities and convert number words to digits.";
 
 #[derive(Deserialize)]
 struct TranscriptionResponse {

--- a/src/handlers/voice.rs
+++ b/src/handlers/voice.rs
@@ -34,6 +34,10 @@ pub async fn add_items_from_voice(
 
     match transcribe_audio(&config.model, &config.api_key, Some(DEFAULT_PROMPT), &audio).await {
         Ok(text) => {
+            if text.trim().is_empty() {
+                tracing::debug!("voice transcription empty; ignoring");
+                return Ok(());
+            }
             let current = list_items(&db, msg.chat.id).await?;
             let list_texts: Vec<String> = current.iter().map(|i| i.text.clone()).collect();
             match interpret_voice_command(&config.api_key, &text, &list_texts).await {


### PR DESCRIPTION
## Summary
- stop converting spelled-out numbers in `parse_item_line`
- adjust STT and GPT prompts to ask for digits when transcribing
- rework tests to match prompt-based behavior
- ignore empty voice transcriptions

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`


------
https://chatgpt.com/codex/tasks/task_e_6845f4456e0c832d8cdc6f33fb6a2fe1