### PR TITLE
Use GPT 4.1 by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
 5. Voice GPT prompt includes the list in JSON form to reduce misunderstandings.
 6. Empty voice transcriptions are ignored instead of confusing the GPT command
    parser.
+7. GPT chat model is configurable via `OPENAI_GPT_MODEL` and now defaults to
+   `gpt-4.1`.
 
 ## [0.2.0] - 2025-06-08
 1. Add items by sending a photo using OpenAI vision to detect items automatically.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Set these environment variables before running:
 - `RUST_LOG` – optional logging level (e.g. `info` or `debug`)
 - `OPENAI_API_KEY` – optional API key for enabling voice and photo recognition
 - `OPENAI_STT_MODEL` – optional model name (`whisper-1`, `gpt-4o-mini-transcribe`, or `gpt-4o-transcribe`)
+- `OPENAI_GPT_MODEL` – optional chat model name (defaults to `gpt-4.1`)
 
 The database file is created automatically if needed. Embedded SQLx migrations in the `migrations/` directory are executed on startup.
 

--- a/fly.toml
+++ b/fly.toml
@@ -9,6 +9,7 @@ image_tag = "latest"
 RUST_LOG = 'trace,hyper=info'
 DB_URL = 'sqlite:///data/shopping.db'
 OPENAI_STT_MODEL = 'gpt-4o-transcribe'
+OPENAI_GPT_MODEL = 'gpt-4.1'
 
 [[mounts]]
 source = 'shopbot_db'

--- a/src/ai/gpt.rs
+++ b/src/ai/gpt.rs
@@ -7,21 +7,26 @@ use tracing::instrument;
 /// The model is instructed to return a JSON object with an `items` array. The
 /// returned list is cleaned with [`crate::text_utils::parse_item_line`].
 #[instrument(level = "trace", skip(api_key))]
-pub async fn parse_items_gpt(api_key: &str, text: &str) -> Result<Vec<String>> {
-    parse_items_gpt_inner(api_key, text, OPENAI_CHAT_URL).await
+pub async fn parse_items_gpt(api_key: &str, model: &str, text: &str) -> Result<Vec<String>> {
+    parse_items_gpt_inner(api_key, model, text, OPENAI_CHAT_URL).await
 }
 
 /// Legacy wrapper for [`parse_items_gpt`] used by voice message handling.
 #[instrument(level = "trace", skip(api_key))]
-pub async fn parse_voice_items_gpt(api_key: &str, text: &str) -> Result<Vec<String>> {
-    parse_items_gpt(api_key, text).await
+pub async fn parse_voice_items_gpt(api_key: &str, model: &str, text: &str) -> Result<Vec<String>> {
+    parse_items_gpt(api_key, model, text).await
 }
 
 #[cfg_attr(not(test), allow(dead_code))]
 #[instrument(level = "trace", skip(api_key))]
-pub async fn parse_items_gpt_inner(api_key: &str, text: &str, url: &str) -> Result<Vec<String>> {
+pub async fn parse_items_gpt_inner(
+    api_key: &str,
+    model: &str,
+    text: &str,
+    url: &str,
+) -> Result<Vec<String>> {
     let body = serde_json::json!({
-        "model": "gpt-3.5-turbo",
+        "model": model,
         "response_format": { "type": "json_object" },
         "messages": [
             {
@@ -37,18 +42,24 @@ pub async fn parse_items_gpt_inner(api_key: &str, text: &str, url: &str) -> Resu
 
 #[cfg_attr(not(test), allow(dead_code))]
 #[instrument(level = "trace", skip(api_key))]
-pub async fn parse_items_gpt_test(api_key: &str, text: &str, url: &str) -> Result<Vec<String>> {
-    parse_items_gpt_inner(api_key, text, url).await
+pub async fn parse_items_gpt_test(
+    api_key: &str,
+    model: &str,
+    text: &str,
+    url: &str,
+) -> Result<Vec<String>> {
+    parse_items_gpt_inner(api_key, model, text, url).await
 }
 
 /// Legacy wrapper for [`parse_items_gpt_test`].
 #[instrument(level = "trace", skip(api_key))]
 pub async fn parse_voice_items_gpt_test(
     api_key: &str,
+    model: &str,
     text: &str,
     url: &str,
 ) -> Result<Vec<String>> {
-    parse_items_gpt_test(api_key, text, url).await
+    parse_items_gpt_test(api_key, model, text, url).await
 }
 
 #[derive(Debug, PartialEq)]
@@ -66,16 +77,18 @@ struct CommandJson {
 #[instrument(level = "trace", skip(api_key))]
 pub async fn interpret_voice_command(
     api_key: &str,
+    model: &str,
     text: &str,
     list: &[String],
 ) -> Result<VoiceCommand> {
-    interpret_voice_command_inner(api_key, text, list, OPENAI_CHAT_URL).await
+    interpret_voice_command_inner(api_key, model, text, list, OPENAI_CHAT_URL).await
 }
 
 #[cfg_attr(not(test), allow(dead_code))]
 #[instrument(level = "trace", skip(api_key))]
 pub async fn interpret_voice_command_inner(
     api_key: &str,
+    model: &str,
     text: &str,
     list: &[String],
     url: &str,
@@ -92,7 +105,7 @@ pub async fn interpret_voice_command_inner(
     );
 
     let body = serde_json::json!({
-        "model": "gpt-3.5-turbo",
+        "model": model,
         "response_format": { "type": "json_object" },
         "messages": [
             { "role": "system", "content": prompt },
@@ -166,9 +179,10 @@ pub async fn interpret_voice_command_inner(
 #[instrument(level = "trace", skip(api_key))]
 pub async fn interpret_voice_command_test(
     api_key: &str,
+    model: &str,
     text: &str,
     list: &[String],
     url: &str,
 ) -> Result<VoiceCommand> {
-    interpret_voice_command_inner(api_key, text, list, url).await
+    interpret_voice_command_inner(api_key, model, text, list, url).await
 }

--- a/src/ai/stt.rs
+++ b/src/ai/stt.rs
@@ -7,6 +7,7 @@ use tracing::{debug, instrument, trace, warn};
 pub struct SttConfig {
     pub api_key: String,
     pub model: String,
+    pub gpt_model: String,
 }
 
 /// Default instructions passed to GPT-based transcription models.

--- a/src/handlers/text.rs
+++ b/src/handlers/text.rs
@@ -66,7 +66,7 @@ pub async fn add_items_from_parsed_text(
         return Ok(());
     };
 
-    let items = match parse_items_gpt(&config.api_key, text).await {
+    let items = match parse_items_gpt(&config.api_key, &config.gpt_model, text).await {
         Ok(list) => list,
         Err(err) => {
             tracing::warn!("gpt parsing failed: {}", err);

--- a/src/handlers/voice.rs
+++ b/src/handlers/voice.rs
@@ -40,7 +40,9 @@ pub async fn add_items_from_voice(
             }
             let current = list_items(&db, msg.chat.id).await?;
             let list_texts: Vec<String> = current.iter().map(|i| i.text.clone()).collect();
-            match interpret_voice_command(&config.api_key, &text, &list_texts).await {
+            match interpret_voice_command(&config.api_key, &config.gpt_model, &text, &list_texts)
+                .await
+            {
                 Ok(VoiceCommand::Add(items)) => {
                     let mut added = 0;
                     for item in items {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ pub async fn run() -> Result<()> {
         Ok(key) => Some(crate::ai::stt::SttConfig {
             api_key: key,
             model: env::var("OPENAI_STT_MODEL").unwrap_or_else(|_| "whisper-1".to_string()),
+            gpt_model: env::var("OPENAI_GPT_MODEL").unwrap_or_else(|_| "gpt-4.1".to_string()),
         }),
         Err(_) => None,
     };

--- a/tests/gpt_parsing.rs
+++ b/tests/gpt_parsing.rs
@@ -15,7 +15,7 @@ async fn test_parse_items_gpt_numbers() {
         .await;
 
     let url = format!("{}/v1/chat/completions", server.uri());
-    let items = parse_items_gpt_test("k", "one milk and 2 eggs", &url)
+    let items = parse_items_gpt_test("k", "gpt-4.1", "one milk and 2 eggs", &url)
         .await
         .unwrap();
     assert_eq!(items, vec!["one milk", "2 eggs"]);

--- a/tests/voice_command.rs
+++ b/tests/voice_command.rs
@@ -17,6 +17,7 @@ async fn test_voice_command_delete() {
     let url = format!("{}/v1/chat/completions", server.uri());
     let res = interpret_voice_command_test(
         "k",
+        "gpt-4.1",
         "delete milk",
         &["Milk".to_string(), "Bread".to_string()],
         &url,
@@ -41,6 +42,7 @@ async fn test_voice_command_add() {
     let url = format!("{}/v1/chat/completions", server.uri());
     let res = interpret_voice_command_test(
         "k",
+        "gpt-4.1",
         "apples",
         &["Milk".to_string(), "Bread".to_string()],
         &url,


### PR DESCRIPTION
## Summary
- switch default GPT model to `gpt-4.1`
- update docs and example config
- adjust tests for the new default

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`


------
https://chatgpt.com/codex/tasks/task_e_684602de3978832d8b8717e387769b94