### PR TITLE
Release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+
+## [0.3.0] - 2025-06-09
 1. `/info` command shows commit hash and release version or how many commits the build is ahead of the latest release
 2. Remove items via voice commands like "delete milk". The bot replies with a copyable list of the deleted entries.
 3. Voice requests prefer nominative item names and numeric quantities when interpreting additions.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2029,7 +2029,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shopbot"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shopbot"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 build = "build.rs"
 


### PR DESCRIPTION
## Summary
- finalize changelog for v0.3.0
- bump manifest version to 0.3.0

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`


------
https://chatgpt.com/codex/tasks/task_e_68460b834c74832dbd9312ff2287904d