### PR TITLE
Add configurable vision model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+1. Vision model configurable via `OPENAI_VISION_MODEL`.
 
 ## [0.3.0] - 2025-06-09
 1. `/info` command shows commit hash and release version or how many commits the build is ahead of the latest release

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Set these environment variables before running:
 - `OPENAI_API_KEY` – optional API key for enabling voice and photo recognition
 - `OPENAI_STT_MODEL` – optional model name (`whisper-1`, `gpt-4o-mini-transcribe`, or `gpt-4o-transcribe`)
 - `OPENAI_GPT_MODEL` – optional chat model name (defaults to `gpt-4.1`)
+- `OPENAI_VISION_MODEL` – optional vision model name (defaults to `gpt-4o`)
 
 The database file is created automatically if needed. Embedded SQLx migrations in the `migrations/` directory are executed on startup.
 

--- a/src/ai.rs
+++ b/src/ai.rs
@@ -1,4 +1,5 @@
 pub mod common;
+pub mod config;
 pub mod gpt;
 pub mod stt;
 pub mod vision;

--- a/src/ai/config.rs
+++ b/src/ai/config.rs
@@ -1,0 +1,7 @@
+#[derive(Clone)]
+pub struct AiConfig {
+    pub api_key: String,
+    pub stt_model: String,
+    pub gpt_model: String,
+    pub vision_model: String,
+}

--- a/src/ai/stt.rs
+++ b/src/ai/stt.rs
@@ -3,13 +3,6 @@ use reqwest::multipart::{Form, Part};
 use serde::Deserialize;
 use tracing::{debug, instrument, trace, warn};
 
-#[derive(Clone)]
-pub struct SttConfig {
-    pub api_key: String,
-    pub model: String,
-    pub gpt_model: String,
-}
-
 /// Default instructions passed to GPT-based transcription models.
 /// The prompt also asks the model to keep verbs intact so commands like
 /// "delete" are not dropped during transcription. Quantities should be

--- a/src/ai/vision.rs
+++ b/src/ai/vision.rs
@@ -4,21 +4,22 @@ use base64::Engine as _;
 use tracing::instrument;
 
 #[instrument(level = "trace", skip(api_key, bytes))]
-pub async fn parse_photo_items(api_key: &str, bytes: &[u8]) -> Result<Vec<String>> {
-    parse_photo_items_inner(api_key, bytes, OPENAI_CHAT_URL).await
+pub async fn parse_photo_items(api_key: &str, model: &str, bytes: &[u8]) -> Result<Vec<String>> {
+    parse_photo_items_inner(api_key, model, bytes, OPENAI_CHAT_URL).await
 }
 
 #[cfg_attr(not(test), allow(dead_code))]
 #[instrument(level = "trace", skip(api_key, bytes))]
 pub async fn parse_photo_items_inner(
     api_key: &str,
+    model: &str,
     bytes: &[u8],
     url: &str,
 ) -> Result<Vec<String>> {
     let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
     let data_url = format!("data:image/png;base64,{}", encoded);
     let body = serde_json::json!({
-        "model": "gpt-4o",
+        "model": model,
         "response_format": { "type": "json_object" },
         "messages": [
             {
@@ -37,6 +38,11 @@ pub async fn parse_photo_items_inner(
 
 #[cfg_attr(not(test), allow(dead_code))]
 #[instrument(level = "trace", skip(api_key, bytes))]
-pub async fn parse_photo_items_test(api_key: &str, bytes: &[u8], url: &str) -> Result<Vec<String>> {
-    parse_photo_items_inner(api_key, bytes, url).await
+pub async fn parse_photo_items_test(
+    api_key: &str,
+    model: &str,
+    bytes: &[u8],
+    url: &str,
+) -> Result<Vec<String>> {
+    parse_photo_items_inner(api_key, model, bytes, url).await
 }

--- a/src/handlers/photo.rs
+++ b/src/handlers/photo.rs
@@ -8,13 +8,13 @@ use crate::db::add_item;
 use crate::text_utils::capitalize_first;
 
 use super::list::send_list;
-use crate::ai::stt::SttConfig;
+use crate::ai::config::AiConfig;
 
 pub async fn add_items_from_photo(
     bot: Bot,
     msg: Message,
     db: Pool<Sqlite>,
-    stt: Option<SttConfig>,
+    stt: Option<AiConfig>,
 ) -> Result<()> {
     let Some(config) = stt else {
         return Ok(());
@@ -37,7 +37,7 @@ pub async fn add_items_from_photo(
         bytes.extend_from_slice(&chunk?);
     }
 
-    let items = match parse_photo_items(&config.api_key, &bytes).await {
+    let items = match parse_photo_items(&config.api_key, &config.vision_model, &bytes).await {
         Ok(list) => list,
         Err(err) => {
             tracing::warn!("photo parsing failed: {}", err);

--- a/src/handlers/text.rs
+++ b/src/handlers/text.rs
@@ -2,8 +2,9 @@ use anyhow::Result;
 use sqlx::{Pool, Sqlite};
 use teloxide::prelude::*;
 
+use crate::ai::config::AiConfig;
 use crate::ai::gpt::parse_items_gpt;
-use crate::ai::stt::{parse_items, SttConfig};
+use crate::ai::stt::parse_items;
 use crate::db::add_item;
 use crate::text_utils::{capitalize_first, parse_item_line};
 
@@ -54,7 +55,7 @@ pub async fn add_items_from_parsed_text(
     bot: Bot,
     msg: Message,
     db: Pool<Sqlite>,
-    stt: Option<SttConfig>,
+    stt: Option<AiConfig>,
 ) -> Result<()> {
     let Some(config) = stt else {
         bot.send_message(msg.chat.id, "GPT parsing is disabled.")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,11 +41,12 @@ pub async fn run() -> Result<()> {
     let bot = Bot::from_env();
 
     // Optional OpenAI speech-to-text configuration
-    let stt_config = match env::var("OPENAI_API_KEY") {
-        Ok(key) => Some(crate::ai::stt::SttConfig {
+    let ai_config = match env::var("OPENAI_API_KEY") {
+        Ok(key) => Some(crate::ai::config::AiConfig {
             api_key: key,
-            model: env::var("OPENAI_STT_MODEL").unwrap_or_else(|_| "whisper-1".to_string()),
+            stt_model: env::var("OPENAI_STT_MODEL").unwrap_or_else(|_| "whisper-1".to_string()),
             gpt_model: env::var("OPENAI_GPT_MODEL").unwrap_or_else(|_| "gpt-4.1".to_string()),
+            vision_model: env::var("OPENAI_VISION_MODEL").unwrap_or_else(|_| "gpt-4o".to_string()),
         }),
         Err(_) => None,
     };
@@ -113,7 +114,7 @@ pub async fn run() -> Result<()> {
                      msg: Message,
                      cmd: Command,
                      db: Pool<Sqlite>,
-                     stt_config: Option<crate::ai::stt::SttConfig>| async move {
+                     ai_config: Option<crate::ai::config::AiConfig>| async move {
                         match cmd {
                             Command::Start | Command::Help => help(bot, msg).await?,
                             Command::List => send_list(bot, msg.chat.id, &db).await?,
@@ -122,7 +123,7 @@ pub async fn run() -> Result<()> {
                             Command::Share => share_list(bot, msg.chat.id, &db).await?,
                             Command::Nuke => nuke_list(bot, msg, &db).await?,
                             Command::Parse => {
-                                add_items_from_parsed_text(bot, msg, db, stt_config).await?
+                                add_items_from_parsed_text(bot, msg, db, ai_config).await?
                             }
                             Command::Info => show_system_info(bot, msg).await?,
                         }
@@ -134,7 +135,7 @@ pub async fn run() -> Result<()> {
 
     // --- Dispatcher ---
     Dispatcher::builder(bot, handler)
-        .dependencies(dptree::deps![db, stt_config])
+        .dependencies(dptree::deps![db, ai_config])
         .enable_ctrlc_handler()
         .build()
         .dispatch()

--- a/tests/vision.rs
+++ b/tests/vision.rs
@@ -15,6 +15,8 @@ async fn test_parse_photo_items() {
         .await;
 
     let url = format!("{}/v1/chat/completions", server.uri());
-    let items = parse_photo_items_test("k", b"img", &url).await.unwrap();
+    let items = parse_photo_items_test("k", "gpt-4o", b"img", &url)
+        .await
+        .unwrap();
     assert_eq!(items, vec!["apples"]);
 }


### PR DESCRIPTION
## Summary
- add new `AiConfig` struct for OpenAI configuration
- read `OPENAI_VISION_MODEL` into `AiConfig`
- pass vision model from handlers to vision functions
- update vision parsing functions to accept a model argument

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`


------
https://chatgpt.com/codex/tasks/task_e_68461d087088832da0bfe063d4cf4453