### PR TITLE
Add Dependabot for Cargo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly


### PR DESCRIPTION
## Summary
- enable Dependabot weekly for Cargo dependencies

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast` *(fails: compilation takes too long in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68469ccdbbb0832d9b86193edd2b48df