### PR TITLE
Relax dependency versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2029,7 +2029,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shopbot"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shopbot"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 build = "build.rs"
 
@@ -20,5 +20,5 @@ base64 = "0.21"
 git-version = "0.3"
 
 [dev-dependencies]
-proptest = "1.6"
+proptest = "1.7"
 wiremock = "0.6"


### PR DESCRIPTION
## Summary
- avoid pinning patch versions in Cargo.toml
- run `cargo update`

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`
- `cargo nextest run --all`


------
https://chatgpt.com/codex/tasks/task_e_6846a0ffc600832d9b1921fa3905601c