### PR TITLE
Add helper to schedule message deletion

### DIFF
--- a/src/handlers/delete.rs
+++ b/src/handlers/delete.rs
@@ -51,10 +51,7 @@ pub async fn enter_delete_mode(bot: Bot, msg: Message, db: &Pool<Sqlite>) -> Res
         let sent_msg = bot
             .send_message(msg.chat.id, "There is no active list to edit.")
             .await?;
-        tokio::spawn(async move {
-            tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
-            let _ = bot.delete_message(sent_msg.chat.id, sent_msg.id).await;
-        });
+        crate::delete_after(bot.clone(), sent_msg.chat.id, sent_msg.id, 5);
         return Ok(());
     }
 
@@ -113,10 +110,7 @@ pub async fn enter_delete_mode(bot: Bot, msg: Message, db: &Pool<Sqlite>) -> Res
                     "Unable to send you a private delete panel. Have you started me in private?",
                 )
                 .await?;
-            tokio::spawn(async move {
-                tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
-                let _ = bot.delete_message(warn.chat.id, warn.id).await;
-            });
+            crate::delete_after(bot.clone(), warn.chat.id, warn.id, 5);
         }
     }
 

--- a/src/handlers/list.rs
+++ b/src/handlers/list.rs
@@ -181,12 +181,7 @@ pub async fn nuke_list(bot: Bot, msg: Message, db: &Pool<Sqlite>) -> Result<()> 
     let confirmation = bot
         .send_message(msg.chat.id, "The active list has been nuked.")
         .await?;
-    tokio::spawn(async move {
-        tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
-        let _ = bot
-            .delete_message(confirmation.chat.id, confirmation.id)
-            .await;
-    });
+    crate::delete_after(bot.clone(), confirmation.chat.id, confirmation.id, 5);
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ mod db;
 mod handlers;
 mod system_info;
 mod text_utils;
+mod utils;
 
 pub use ai::gpt::{parse_items_gpt, parse_voice_items_gpt};
 pub use ai::stt::{parse_items, parse_voice_items};
@@ -16,6 +17,7 @@ pub use db::Item;
 pub use handlers::{format_delete_list, format_list, format_plain_list};
 pub use system_info::get_system_info;
 pub use text_utils::{capitalize_first, normalize_for_match, parse_item_line};
+pub use utils::delete_after;
 
 use handlers::{
     add_items_from_parsed_text, add_items_from_photo, add_items_from_text, add_items_from_voice,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,18 @@
+use teloxide::{
+    prelude::*,
+    types::{ChatId, MessageId},
+};
+
+/// Delete a message after the given delay in seconds.
+pub fn delete_after(bot: Bot, chat_id: ChatId, message_id: MessageId, secs: u64) {
+    tracing::debug!(
+        chat_id = chat_id.0,
+        message_id = message_id.0,
+        delay_secs = secs,
+        "Scheduling message deletion"
+    );
+    tokio::spawn(async move {
+        tokio::time::sleep(std::time::Duration::from_secs(secs)).await;
+        let _ = bot.delete_message(chat_id, message_id).await;
+    });
+}

--- a/tests/delete_utils.rs
+++ b/tests/delete_utils.rs
@@ -1,0 +1,23 @@
+use shopbot::delete_after;
+use teloxide::{prelude::*, types::MessageId};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn test_delete_after_sends_request() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/botTEST/DeleteMessage"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_raw(r#"{"ok":true,"result":true}"#, "application/json"),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let bot = Bot::new("TEST").set_api_url(reqwest::Url::parse(&server.uri()).unwrap());
+    delete_after(bot, ChatId(1), MessageId(2), 0);
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    server.verify().await;
+}


### PR DESCRIPTION
## Summary
- add `delete_after` utility
- replace inline `tokio::spawn` calls in handlers with new helper
- log when scheduling deletions
- test deletion helper

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`

------
https://chatgpt.com/codex/tasks/task_e_6847469a9070832d9351e6079adeb8e4