### PR TITLE
Remove *_test wrappers for OpenAI modules

### DIFF
--- a/src/ai/gpt.rs
+++ b/src/ai/gpt.rs
@@ -7,14 +7,25 @@ use tracing::instrument;
 /// The model is instructed to return a JSON object with an `items` array. The
 /// returned list is cleaned with [`crate::text_utils::parse_item_line`].
 #[instrument(level = "trace", skip(api_key))]
-pub async fn parse_items_gpt(api_key: &str, model: &str, text: &str) -> Result<Vec<String>> {
-    parse_items_gpt_inner(api_key, model, text, OPENAI_CHAT_URL).await
+pub async fn parse_items_gpt(
+    api_key: &str,
+    model: &str,
+    text: &str,
+    url: Option<&str>,
+) -> Result<Vec<String>> {
+    let url = url.unwrap_or(OPENAI_CHAT_URL);
+    parse_items_gpt_inner(api_key, model, text, url).await
 }
 
 /// Legacy wrapper for [`parse_items_gpt`] used by voice message handling.
 #[instrument(level = "trace", skip(api_key))]
-pub async fn parse_voice_items_gpt(api_key: &str, model: &str, text: &str) -> Result<Vec<String>> {
-    parse_items_gpt(api_key, model, text).await
+pub async fn parse_voice_items_gpt(
+    api_key: &str,
+    model: &str,
+    text: &str,
+    url: Option<&str>,
+) -> Result<Vec<String>> {
+    parse_items_gpt(api_key, model, text, url).await
 }
 
 #[cfg_attr(not(test), allow(dead_code))]
@@ -38,28 +49,6 @@ pub async fn parse_items_gpt_inner(
     });
 
     request_items(api_key, &body, url).await
-}
-
-#[cfg_attr(not(test), allow(dead_code))]
-#[instrument(level = "trace", skip(api_key))]
-pub async fn parse_items_gpt_test(
-    api_key: &str,
-    model: &str,
-    text: &str,
-    url: &str,
-) -> Result<Vec<String>> {
-    parse_items_gpt_inner(api_key, model, text, url).await
-}
-
-/// Legacy wrapper for [`parse_items_gpt_test`].
-#[instrument(level = "trace", skip(api_key))]
-pub async fn parse_voice_items_gpt_test(
-    api_key: &str,
-    model: &str,
-    text: &str,
-    url: &str,
-) -> Result<Vec<String>> {
-    parse_items_gpt_test(api_key, model, text, url).await
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/ai/stt.rs
+++ b/src/ai/stt.rs
@@ -61,19 +61,9 @@ pub async fn transcribe_audio(
     api_key: &str,
     prompt: Option<&str>,
     bytes: &[u8],
+    url: Option<&str>,
 ) -> Result<String> {
-    transcribe_audio_inner(model, api_key, prompt, bytes, OPENAI_URL).await
-}
-
-#[cfg_attr(not(test), allow(dead_code))]
-#[instrument(level = "trace", skip(api_key, bytes))]
-pub async fn transcribe_audio_test(
-    model: &str,
-    api_key: &str,
-    prompt: Option<&str>,
-    bytes: &[u8],
-    url: &str,
-) -> Result<String> {
+    let url = url.unwrap_or(OPENAI_URL);
     transcribe_audio_inner(model, api_key, prompt, bytes, url).await
 }
 

--- a/src/ai/vision.rs
+++ b/src/ai/vision.rs
@@ -4,8 +4,14 @@ use base64::Engine as _;
 use tracing::instrument;
 
 #[instrument(level = "trace", skip(api_key, bytes))]
-pub async fn parse_photo_items(api_key: &str, model: &str, bytes: &[u8]) -> Result<Vec<String>> {
-    parse_photo_items_inner(api_key, model, bytes, OPENAI_CHAT_URL).await
+pub async fn parse_photo_items(
+    api_key: &str,
+    model: &str,
+    bytes: &[u8],
+    url: Option<&str>,
+) -> Result<Vec<String>> {
+    let url = url.unwrap_or(OPENAI_CHAT_URL);
+    parse_photo_items_inner(api_key, model, bytes, url).await
 }
 
 #[cfg_attr(not(test), allow(dead_code))]
@@ -34,15 +40,4 @@ pub async fn parse_photo_items_inner(
     });
 
     request_items(api_key, &body, url).await
-}
-
-#[cfg_attr(not(test), allow(dead_code))]
-#[instrument(level = "trace", skip(api_key, bytes))]
-pub async fn parse_photo_items_test(
-    api_key: &str,
-    model: &str,
-    bytes: &[u8],
-    url: &str,
-) -> Result<Vec<String>> {
-    parse_photo_items_inner(api_key, model, bytes, url).await
 }

--- a/src/handlers/photo.rs
+++ b/src/handlers/photo.rs
@@ -42,7 +42,7 @@ pub async fn add_items_from_photo(
     tracing::trace!(size = bytes.len(), "downloaded photo bytes");
 
     tracing::debug!(model = %config.vision_model, "parsing photo with OpenAI vision");
-    let items = match parse_photo_items(&config.api_key, &config.vision_model, &bytes).await {
+    let items = match parse_photo_items(&config.api_key, &config.vision_model, &bytes, None).await {
         Ok(list) => list,
         Err(err) => {
             tracing::warn!("photo parsing failed: {}", err);

--- a/src/handlers/text.rs
+++ b/src/handlers/text.rs
@@ -67,7 +67,7 @@ pub async fn add_items_from_parsed_text(
         return Ok(());
     };
 
-    let items = match parse_items_gpt(&config.api_key, &config.gpt_model, text).await {
+    let items = match parse_items_gpt(&config.api_key, &config.gpt_model, text, None).await {
         Ok(list) => list,
         Err(err) => {
             tracing::warn!("gpt parsing failed: {}", err);

--- a/src/handlers/voice.rs
+++ b/src/handlers/voice.rs
@@ -60,6 +60,7 @@ pub async fn add_items_from_voice(
         &config.api_key,
         Some(DEFAULT_PROMPT),
         &audio,
+        None,
     )
     .await
     {

--- a/tests/gpt_parsing.rs
+++ b/tests/gpt_parsing.rs
@@ -1,4 +1,4 @@
-use shopbot::ai::gpt::parse_items_gpt_test;
+use shopbot::ai::gpt::parse_items_gpt;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -15,7 +15,7 @@ async fn test_parse_items_gpt_numbers() {
         .await;
 
     let url = format!("{}/v1/chat/completions", server.uri());
-    let items = parse_items_gpt_test("k", "gpt-4.1", "one milk and 2 eggs", &url)
+    let items = parse_items_gpt("k", "gpt-4.1", "one milk and 2 eggs", Some(&url))
         .await
         .unwrap();
     assert_eq!(items, vec!["one milk", "2 eggs"]);

--- a/tests/stt.rs
+++ b/tests/stt.rs
@@ -1,4 +1,4 @@
-use shopbot::ai::stt::transcribe_audio_test;
+use shopbot::ai::stt::transcribe_audio;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -14,7 +14,7 @@ async fn test_transcribe_audio_parsing() {
         .await;
 
     let url = format!("{}/v1/audio/transcriptions", server.uri());
-    let res = transcribe_audio_test("whisper-1", "k", None, b"123", &url)
+    let res = transcribe_audio("whisper-1", "k", None, b"123", Some(&url))
         .await
         .unwrap();
     assert_eq!(res, "milk");

--- a/tests/vision.rs
+++ b/tests/vision.rs
@@ -1,4 +1,4 @@
-use shopbot::ai::vision::parse_photo_items_test;
+use shopbot::ai::vision::parse_photo_items;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -15,7 +15,7 @@ async fn test_parse_photo_items() {
         .await;
 
     let url = format!("{}/v1/chat/completions", server.uri());
-    let items = parse_photo_items_test("k", "gpt-4o", b"img", &url)
+    let items = parse_photo_items("k", "gpt-4o", b"img", Some(&url))
         .await
         .unwrap();
     assert_eq!(items, vec!["apples"]);


### PR DESCRIPTION
## Summary
- make parse_items_gpt, parse_voice_items_gpt accept optional URL
- make transcribe_audio accept optional URL
- make parse_photo_items accept optional URL
- remove *_test wrappers and update handlers/tests

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`


------
https://chatgpt.com/codex/tasks/task_e_684746a2dfc8832d8d39dfcdd5142fa1