### PR TITLE
Use ai_config parameter name

### DIFF
--- a/src/handlers/photo.rs
+++ b/src/handlers/photo.rs
@@ -14,9 +14,9 @@ pub async fn add_items_from_photo(
     bot: Bot,
     msg: Message,
     db: Pool<Sqlite>,
-    stt: Option<AiConfig>,
+    ai_config: Option<AiConfig>,
 ) -> Result<()> {
-    let Some(config) = stt else {
+    let Some(config) = ai_config else {
         return Ok(());
     };
 
@@ -80,14 +80,14 @@ mod tests {
         let bot = Bot::new("test");
         let json = r#"{"message_id":1,"date":0,"chat":{"id":1,"type":"private"},"photo":[]}"#;
         let msg: Message = serde_json::from_str(json).unwrap();
-        let stt = Some(AiConfig {
+        let ai_config = Some(AiConfig {
             api_key: "k".into(),
             stt_model: "m".into(),
             gpt_model: "g".into(),
             vision_model: "v".into(),
         });
 
-        let res = add_items_from_photo(bot, msg, db, stt).await;
+        let res = add_items_from_photo(bot, msg, db, ai_config).await;
         assert!(res.is_ok());
     }
 }

--- a/src/handlers/text.rs
+++ b/src/handlers/text.rs
@@ -55,9 +55,9 @@ pub async fn add_items_from_parsed_text(
     bot: Bot,
     msg: Message,
     db: Pool<Sqlite>,
-    stt: Option<AiConfig>,
+    ai_config: Option<AiConfig>,
 ) -> Result<()> {
-    let Some(config) = stt else {
+    let Some(config) = ai_config else {
         bot.send_message(msg.chat.id, "GPT parsing is disabled.")
             .await?;
         return Ok(());

--- a/src/handlers/voice.rs
+++ b/src/handlers/voice.rs
@@ -37,9 +37,9 @@ pub async fn add_items_from_voice(
     bot: Bot,
     msg: Message,
     db: Pool<Sqlite>,
-    stt: Option<AiConfig>,
+    ai_config: Option<AiConfig>,
 ) -> Result<()> {
-    let Some(config) = stt else {
+    let Some(config) = ai_config else {
         return Ok(());
     };
 


### PR DESCRIPTION
## Summary
- rename `stt` parameter to `ai_config` across handlers
- update tests and internal uses to new name

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast` *(fails: command did not complete within the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68475075e4a0832d9cf40878c11a122c