### PR TITLE
Introduce file download helper

### DIFF
--- a/src/handlers/photo.rs
+++ b/src/handlers/photo.rs
@@ -1,7 +1,7 @@
+use crate::utils::download_file;
 use anyhow::Result;
-use futures_util::StreamExt;
 use sqlx::{Pool, Sqlite};
-use teloxide::{net::Download, prelude::*};
+use teloxide::prelude::*;
 
 use crate::ai::vision::parse_photo_items;
 use crate::db::add_item;
@@ -34,11 +34,7 @@ pub async fn add_items_from_photo(
     };
 
     let file = bot.get_file(file_id).await?;
-    let mut bytes = Vec::new();
-    let mut stream = bot.download_file_stream(&file.path);
-    while let Some(chunk) = stream.next().await {
-        bytes.extend_from_slice(&chunk?);
-    }
+    let bytes = download_file(&bot, &file.path).await?;
     tracing::trace!(size = bytes.len(), "downloaded photo bytes");
 
     tracing::debug!(model = %config.vision_model, "parsing photo with OpenAI vision");

--- a/src/handlers/voice.rs
+++ b/src/handlers/voice.rs
@@ -1,7 +1,7 @@
+use crate::utils::download_file;
 use anyhow::Result;
-use futures_util::StreamExt;
 use sqlx::{Pool, Sqlite};
-use teloxide::{net::Download, prelude::*};
+use teloxide::prelude::*;
 
 use crate::ai::config::AiConfig;
 use crate::ai::gpt::{interpret_voice_command, VoiceCommand};
@@ -49,11 +49,7 @@ pub async fn add_items_from_voice(
     };
 
     let file = bot.get_file(&voice.file.id).await?;
-    let mut audio = Vec::new();
-    let mut stream = bot.download_file_stream(&file.path);
-    while let Some(chunk) = stream.next().await {
-        audio.extend_from_slice(&chunk?);
-    }
+    let audio = download_file(&bot, &file.path).await?;
 
     match transcribe_audio(
         &config.stt_model,


### PR DESCRIPTION
## Summary
- add `download_file` helper that returns bytes for a Telegram file
- use helper to simplify photo and voice handlers

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`


------
https://chatgpt.com/codex/tasks/task_e_6847507929a0832da1bbafdd8e514cf2