### PR TITLE
Refactor config loading with AiConfig::from_env

### DIFF
--- a/src/ai/config.rs
+++ b/src/ai/config.rs
@@ -1,7 +1,23 @@
+use std::env;
 #[derive(Clone)]
 pub struct AiConfig {
     pub api_key: String,
     pub stt_model: String,
     pub gpt_model: String,
     pub vision_model: String,
+}
+
+impl AiConfig {
+    pub fn from_env() -> Option<Self> {
+        let api_key = match env::var("OPENAI_API_KEY") {
+            Ok(k) => k,
+            Err(_) => return None,
+        };
+        Some(Self {
+            api_key,
+            stt_model: env::var("OPENAI_STT_MODEL").unwrap_or_else(|_| "whisper-1".to_string()),
+            gpt_model: env::var("OPENAI_GPT_MODEL").unwrap_or_else(|_| "gpt-4.1".to_string()),
+            vision_model: env::var("OPENAI_VISION_MODEL").unwrap_or_else(|_| "gpt-4o".to_string()),
+        })
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,16 +12,7 @@ impl Config {
     pub fn from_env() -> Self {
         dotenvy::dotenv().ok();
         let db_url = env::var("DB_URL").unwrap_or_else(|_| "sqlite:shopping.db".to_string());
-        let ai = match env::var("OPENAI_API_KEY") {
-            Ok(key) => Some(AiConfig {
-                api_key: key,
-                stt_model: env::var("OPENAI_STT_MODEL").unwrap_or_else(|_| "whisper-1".to_string()),
-                gpt_model: env::var("OPENAI_GPT_MODEL").unwrap_or_else(|_| "gpt-4.1".to_string()),
-                vision_model: env::var("OPENAI_VISION_MODEL")
-                    .unwrap_or_else(|_| "gpt-4o".to_string()),
-            }),
-            Err(_) => None,
-        };
+        let ai = AiConfig::from_env();
         Self { db_url, ai }
     }
 }

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1,0 +1,50 @@
+use shopbot::ai::config::AiConfig;
+use shopbot::Config;
+
+#[test]
+fn ai_config_from_env_missing_key() {
+    std::env::remove_var("OPENAI_API_KEY");
+    std::env::remove_var("OPENAI_STT_MODEL");
+    std::env::remove_var("OPENAI_GPT_MODEL");
+    std::env::remove_var("OPENAI_VISION_MODEL");
+    assert!(AiConfig::from_env().is_none());
+}
+
+#[test]
+fn ai_config_from_env_defaults() {
+    std::env::set_var("OPENAI_API_KEY", "k");
+    std::env::remove_var("OPENAI_STT_MODEL");
+    std::env::remove_var("OPENAI_GPT_MODEL");
+    std::env::remove_var("OPENAI_VISION_MODEL");
+    let cfg = AiConfig::from_env().unwrap();
+    assert_eq!(cfg.api_key, "k");
+    assert_eq!(cfg.stt_model, "whisper-1");
+    assert_eq!(cfg.gpt_model, "gpt-4.1");
+    assert_eq!(cfg.vision_model, "gpt-4o");
+}
+
+#[test]
+fn ai_config_from_env_custom_models() {
+    std::env::set_var("OPENAI_API_KEY", "k");
+    std::env::set_var("OPENAI_STT_MODEL", "s");
+    std::env::set_var("OPENAI_GPT_MODEL", "g");
+    std::env::set_var("OPENAI_VISION_MODEL", "v");
+    let cfg = AiConfig::from_env().unwrap();
+    assert_eq!(cfg.stt_model, "s");
+    assert_eq!(cfg.gpt_model, "g");
+    assert_eq!(cfg.vision_model, "v");
+}
+
+#[test]
+fn config_from_env_calls_ai_constructor() {
+    std::env::set_var("DB_URL", "db");
+    std::env::set_var("OPENAI_API_KEY", "k");
+    std::env::remove_var("OPENAI_STT_MODEL");
+    std::env::remove_var("OPENAI_GPT_MODEL");
+    std::env::remove_var("OPENAI_VISION_MODEL");
+    let cfg = Config::from_env();
+    assert_eq!(cfg.db_url, "db");
+    let ai = cfg.ai.unwrap();
+    assert_eq!(ai.api_key, "k");
+    assert_eq!(ai.stt_model, "whisper-1");
+}


### PR DESCRIPTION
## Summary
- add `AiConfig::from_env` to centralize AI environment config loading
- use this constructor in `Config::from_env`
- verify new behavior with new tests

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`

------
https://chatgpt.com/codex/tasks/task_e_68475e62e9c4832db1b3ed5830d1edad