### PR TITLE
Use single parsing helpers

### DIFF
--- a/src/ai/gpt.rs
+++ b/src/ai/gpt.rs
@@ -17,17 +17,6 @@ pub async fn parse_items_gpt(
     parse_items_gpt_inner(api_key, model, text, url).await
 }
 
-/// Legacy wrapper for [`parse_items_gpt`] used by voice message handling.
-#[instrument(level = "trace", skip(api_key))]
-pub async fn parse_voice_items_gpt(
-    api_key: &str,
-    model: &str,
-    text: &str,
-    url: Option<&str>,
-) -> Result<Vec<String>> {
-    parse_items_gpt(api_key, model, text, url).await
-}
-
 #[cfg_attr(not(test), allow(dead_code))]
 #[instrument(level = "trace", skip(api_key))]
 pub async fn parse_items_gpt_inner(

--- a/src/ai/stt.rs
+++ b/src/ai/stt.rs
@@ -67,24 +67,14 @@ pub async fn transcribe_audio(
     transcribe_audio_inner(model, api_key, prompt, bytes, url).await
 }
 
-/// Split a transcription string from speech-to-text into individual items.
-///
-/// The text is split on commas, newlines and the word "and". Each segment is
-/// then cleaned via [`crate::text_utils::parse_item_line`]. Empty segments are
-/// ignored.
 /// Split a text string into individual items.
 ///
 /// The input is split on commas, newlines and the word "and". Each segment is
-/// then cleaned via [`crate::text_utils::parse_item_line`]. Empty segments are
+/// cleaned via [`crate::text_utils::parse_item_line`]. Empty segments are
 /// ignored.
 pub fn parse_items(text: &str) -> Vec<String> {
     text.split([',', '\n'])
         .flat_map(|seg| seg.split(" and "))
         .filter_map(crate::text_utils::parse_item_line)
         .collect()
-}
-
-/// Legacy wrapper for [`parse_items`] used by older code paths.
-pub fn parse_voice_items(text: &str) -> Vec<String> {
-    parse_items(text)
 }

--- a/src/handlers/voice.rs
+++ b/src/handlers/voice.rs
@@ -5,7 +5,7 @@ use teloxide::prelude::*;
 
 use crate::ai::config::AiConfig;
 use crate::ai::gpt::{interpret_voice_command, VoiceCommand};
-use crate::ai::stt::{parse_voice_items, transcribe_audio, DEFAULT_PROMPT};
+use crate::ai::stt::{parse_items, transcribe_audio, DEFAULT_PROMPT};
 #[cfg(test)]
 use crate::db::add_item;
 use crate::db::{delete_item, list_items};
@@ -101,7 +101,7 @@ pub async fn add_items_from_voice(
                 }
                 Err(err) => {
                     tracing::warn!("gpt command failed: {}", err);
-                    let items = parse_voice_items(&text);
+                    let items = parse_items(&text);
                     let items: Vec<String> =
                         items.into_iter().map(|i| capitalize_first(&i)).collect();
                     let added = insert_items(bot.clone(), msg.chat.id, &db, items).await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,8 @@ mod utils;
 #[cfg(test)]
 pub mod tests;
 
-pub use ai::gpt::{parse_items_gpt, parse_voice_items_gpt};
-pub use ai::stt::{parse_items, parse_voice_items};
+pub use ai::gpt::parse_items_gpt;
+pub use ai::stt::parse_items;
 pub use config::Config;
 pub use db::Item;
 pub use handlers::{format_delete_list, format_list, format_plain_list, insert_items};


### PR DESCRIPTION
## Summary
- remove legacy parsing functions
- update voice handler to use generic helpers
- clean up exports and docs

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`


------
https://chatgpt.com/codex/tasks/task_e_68475e5d403c832d968692d47a1bd3f7