### PR TITLE
Reuse shared test DB helper

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@ mod system_info;
 mod text_utils;
 mod utils;
 
-#[cfg(test)]
 pub mod tests;
 
 pub use ai::gpt::{parse_items_gpt, parse_voice_items_gpt};

--- a/tests/insert_items.rs
+++ b/tests/insert_items.rs
@@ -1,39 +1,8 @@
 use shopbot::insert_items;
-use sqlx::{sqlite::SqlitePoolOptions, Pool, Sqlite};
+use shopbot::tests::util::init_test_db;
 use teloxide::prelude::*;
 use wiremock::matchers::method;
 use wiremock::{Mock, MockServer, ResponseTemplate};
-
-async fn init_test_db() -> Pool<Sqlite> {
-    let db = SqlitePoolOptions::new()
-        .max_connections(1)
-        .connect("sqlite::memory:")
-        .await
-        .expect("failed to create in-memory database");
-
-    sqlx::query(
-        "CREATE TABLE items(\n    id INTEGER PRIMARY KEY AUTOINCREMENT,\n    chat_id INTEGER NOT NULL,\n    text TEXT NOT NULL,\n    done BOOLEAN NOT NULL DEFAULT 0\n)",
-    )
-    .execute(&db)
-    .await
-    .unwrap();
-
-    sqlx::query(
-        "CREATE TABLE chat_state(\n    chat_id INTEGER PRIMARY KEY,\n    last_list_message_id INTEGER\n)",
-    )
-    .execute(&db)
-    .await
-    .unwrap();
-
-    sqlx::query(
-        "CREATE TABLE delete_session(\n    user_id INTEGER PRIMARY KEY,\n    chat_id INTEGER NOT NULL,\n    selected TEXT NOT NULL DEFAULT '',\n    notice_chat_id INTEGER,\n    notice_message_id INTEGER,\n    dm_message_id INTEGER\n)",
-    )
-    .execute(&db)
-    .await
-    .unwrap();
-
-    db
-}
 
 #[tokio::test]
 async fn insert_items_adds_and_sends() {


### PR DESCRIPTION
## Summary
- share test DB initialization via `shopbot::tests::util`

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`


------
https://chatgpt.com/codex/tasks/task_e_68475e24a084832dabe59f2efb7a097f