### PR TITLE
Refactor OpenAI request bodies

### DIFF
--- a/src/ai/common.rs
+++ b/src/ai/common.rs
@@ -24,6 +24,41 @@ struct ItemsJson {
 
 pub const OPENAI_CHAT_URL: &str = "https://api.openai.com/v1/chat/completions";
 
+/// Build a chat completion request body for text input.
+pub fn build_text_chat_body(
+    model: &str,
+    system_prompt: &str,
+    user_text: &str,
+) -> serde_json::Value {
+    serde_json::json!({
+        "model": model,
+        "response_format": { "type": "json_object" },
+        "messages": [
+            { "role": "system", "content": system_prompt },
+            { "role": "user", "content": user_text },
+        ]
+    })
+}
+
+/// Build a chat completion request body for an image input.
+pub fn build_image_chat_body(
+    model: &str,
+    system_prompt: &str,
+    image_url: &str,
+) -> serde_json::Value {
+    serde_json::json!({
+        "model": model,
+        "response_format": { "type": "json_object" },
+        "messages": [
+            { "role": "system", "content": system_prompt },
+            {
+                "role": "user",
+                "content": [ { "type": "image_url", "image_url": { "url": image_url } } ],
+            }
+        ]
+    })
+}
+
 #[instrument(level = "trace", skip(api_key, builder))]
 pub async fn send_openai_request(
     api_key: &str,

--- a/src/ai/gpt.rs
+++ b/src/ai/gpt.rs
@@ -25,17 +25,8 @@ pub async fn parse_items_gpt_inner(
     text: &str,
     url: &str,
 ) -> Result<Vec<String>> {
-    let body = serde_json::json!({
-        "model": model,
-        "response_format": { "type": "json_object" },
-        "messages": [
-            {
-                "role": "system",
-                "content": "Extract the items from the user's text. Use the nominative form for nouns when it does not change the meaning. Convert number words to digits so 'три ананаса' becomes '3 ананаса'. Respond with a JSON object like {\"items\": [\"1 milk\"]}",
-            },
-            { "role": "user", "content": text },
-        ]
-    });
+    let prompt = "Extract the items from the user's text. Use the nominative form for nouns when it does not change the meaning. Convert number words to digits so 'три ананаса' becomes '3 ананаса'. Respond with a JSON object like {\"items\": [\"1 milk\"]}";
+    let body = crate::ai::common::build_text_chat_body(model, prompt, text);
 
     request_items(api_key, &body, url).await
 }
@@ -82,14 +73,7 @@ pub async fn interpret_voice_command_inner(
         "You manage a list of items. {list_text} The list as JSON is {list_json}. Decide whether the user's request adds items or removes items from the list. Return a JSON object like {{\"add\":[...]}} or {{\"delete\":[...]}}. For deletions, include each item exactly as it appears in the list, including any leading quantities. If unsure, treat it as an addition request. Use nominative forms for item names when possible and convert number words to digits."
     );
 
-    let body = serde_json::json!({
-        "model": model,
-        "response_format": { "type": "json_object" },
-        "messages": [
-            { "role": "system", "content": prompt },
-            { "role": "user", "content": text },
-        ]
-    });
+    let body = crate::ai::common::build_text_chat_body(model, &prompt, text);
 
     #[derive(serde::Deserialize)]
     struct ChatChoice {

--- a/src/ai/vision.rs
+++ b/src/ai/vision.rs
@@ -24,20 +24,8 @@ pub async fn parse_photo_items_inner(
 ) -> Result<Vec<String>> {
     let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
     let data_url = format!("data:image/png;base64,{}", encoded);
-    let body = serde_json::json!({
-        "model": model,
-        "response_format": { "type": "json_object" },
-        "messages": [
-            {
-                "role": "system",
-                "content": "Extract the items shown in the photo. Respond with a JSON object like {\"items\": [\"apples\"]}.",
-            },
-            {
-                "role": "user",
-                "content": [ { "type": "image_url", "image_url": { "url": data_url } } ],
-            }
-        ]
-    });
+    let prompt = "Extract the items shown in the photo. Respond with a JSON object like {\"items\": [\"apples\"]}.";
+    let body = crate::ai::common::build_image_chat_body(model, prompt, &data_url);
 
     request_items(api_key, &body, url).await
 }


### PR DESCRIPTION
## Summary
- add helpers for building text or image chat completion bodies
- simplify GPT item and photo parsing to use helpers
- reuse helpers for voice command interpretation

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast -- --test-threads=1`


------
https://chatgpt.com/codex/tasks/task_e_6847653b40cc832db47df6c975efc779