### PR TITLE
Refactor DB API around Database struct

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -4,21 +4,13 @@ use anyhow::Result;
 use sqlx::{sqlite::SqlitePoolOptions, Pool, Sqlite};
 
 pub mod chat_state;
+pub mod database;
 pub mod delete_session;
 pub mod items;
 
-pub use chat_state::{
-    clear_last_list_message_id, get_last_list_message_id, update_last_list_message_id,
-};
-#[allow(unused_imports)]
-pub use delete_session::DeleteSession;
-pub use delete_session::{
-    clear_delete_session, get_delete_session, init_delete_session, set_delete_dm_message,
-    set_delete_notice, update_delete_selection,
-};
-pub use items::{
-    add_item, delete_all_items, delete_item, delete_items, list_items, toggle_item, Item,
-};
+pub use database::Database;
+
+pub use items::Item;
 
 pub fn prepare_sqlite_url(url: &str) -> String {
     if url.starts_with("sqlite:") && !url.contains("mode=") && !url.contains(":memory:") {

--- a/src/db/chat_state.rs
+++ b/src/db/chat_state.rs
@@ -1,5 +1,5 @@
+use super::Database;
 use anyhow::Result;
-use sqlx::{Pool, Sqlite};
 use teloxide::types::{ChatId, MessageId};
 
 #[derive(sqlx::FromRow)]
@@ -7,43 +7,45 @@ struct ChatState {
     last_list_message_id: i32,
 }
 
-pub async fn get_last_list_message_id(db: &Pool<Sqlite>, chat_id: ChatId) -> Result<Option<i32>> {
-    tracing::trace!(chat_id = chat_id.0, "Fetching last list message id");
-    let result = sqlx::query_as::<_, ChatState>(
-        "SELECT last_list_message_id FROM chat_state WHERE chat_id = ?",
-    )
-    .bind(chat_id.0)
-    .fetch_optional(db)
-    .await?;
-    Ok(result.map(|r| r.last_list_message_id))
-}
-
-pub async fn update_last_list_message_id(
-    db: &Pool<Sqlite>,
-    chat_id: ChatId,
-    message_id: MessageId,
-) -> Result<()> {
-    tracing::debug!(
-        chat_id = chat_id.0,
-        message_id = message_id.0,
-        "Updating last list message id",
-    );
-    sqlx::query(
-        "INSERT INTO chat_state (chat_id, last_list_message_id) VALUES (?, ?) \
-         ON CONFLICT(chat_id) DO UPDATE SET last_list_message_id = excluded.last_list_message_id",
-    )
-    .bind(chat_id.0)
-    .bind(message_id.0)
-    .execute(db)
-    .await?;
-    Ok(())
-}
-
-pub async fn clear_last_list_message_id(db: &Pool<Sqlite>, chat_id: ChatId) -> Result<()> {
-    tracing::debug!(chat_id = chat_id.0, "Clearing last list message id");
-    sqlx::query("DELETE FROM chat_state WHERE chat_id = ?")
+impl Database {
+    pub async fn get_last_list_message_id(&self, chat_id: ChatId) -> Result<Option<i32>> {
+        tracing::trace!(chat_id = chat_id.0, "Fetching last list message id");
+        let result = sqlx::query_as::<_, ChatState>(
+            "SELECT last_list_message_id FROM chat_state WHERE chat_id = ?",
+        )
         .bind(chat_id.0)
-        .execute(db)
+        .fetch_optional(self.pool())
         .await?;
-    Ok(())
+        Ok(result.map(|r| r.last_list_message_id))
+    }
+
+    pub async fn update_last_list_message_id(
+        &self,
+        chat_id: ChatId,
+        message_id: MessageId,
+    ) -> Result<()> {
+        tracing::debug!(
+            chat_id = chat_id.0,
+            message_id = message_id.0,
+            "Updating last list message id",
+        );
+        sqlx::query(
+            "INSERT INTO chat_state (chat_id, last_list_message_id) VALUES (?, ?) \
+             ON CONFLICT(chat_id) DO UPDATE SET last_list_message_id = excluded.last_list_message_id",
+        )
+        .bind(chat_id.0)
+        .bind(message_id.0)
+        .execute(self.pool())
+        .await?;
+        Ok(())
+    }
+
+    pub async fn clear_last_list_message_id(&self, chat_id: ChatId) -> Result<()> {
+        tracing::debug!(chat_id = chat_id.0, "Clearing last list message id");
+        sqlx::query("DELETE FROM chat_state WHERE chat_id = ?")
+            .bind(chat_id.0)
+            .execute(self.pool())
+            .await?;
+        Ok(())
+    }
 }

--- a/src/db/database.rs
+++ b/src/db/database.rs
@@ -1,0 +1,23 @@
+use sqlx::{Pool, Sqlite};
+
+#[derive(Clone)]
+pub struct Database {
+    pool: Pool<Sqlite>,
+}
+
+impl Database {
+    pub fn new(pool: Pool<Sqlite>) -> Self {
+        Self { pool }
+    }
+
+    pub fn pool(&self) -> &Pool<Sqlite> {
+        &self.pool
+    }
+}
+
+impl std::ops::Deref for Database {
+    type Target = Pool<Sqlite>;
+    fn deref(&self) -> &Self::Target {
+        &self.pool
+    }
+}

--- a/src/db/items.rs
+++ b/src/db/items.rs
@@ -1,5 +1,5 @@
+use super::Database;
 use anyhow::Result;
-use sqlx::{Pool, Sqlite};
 use teloxide::types::ChatId;
 
 #[derive(sqlx::FromRow, Debug, Clone, PartialEq)]
@@ -9,64 +9,66 @@ pub struct Item {
     pub done: bool,
 }
 
-pub async fn add_item(db: &Pool<Sqlite>, chat_id: ChatId, text: &str) -> Result<()> {
-    tracing::trace!(chat_id = chat_id.0, text = %text, "Adding item");
-    sqlx::query("INSERT INTO items (chat_id, text) VALUES (?, ?)")
-        .bind(chat_id.0)
-        .bind(text)
-        .execute(db)
-        .await?;
-    Ok(())
-}
-
-pub async fn list_items(db: &Pool<Sqlite>, chat_id: ChatId) -> Result<Vec<Item>> {
-    tracing::trace!(chat_id = chat_id.0, "Listing items");
-    sqlx::query_as("SELECT id, text, done FROM items WHERE chat_id = ? ORDER BY id")
-        .bind(chat_id.0)
-        .fetch_all(db)
-        .await
-        .map_err(Into::into)
-}
-
-pub async fn toggle_item(db: &Pool<Sqlite>, id: i64) -> Result<()> {
-    tracing::trace!(item_id = id, "Toggling item");
-    sqlx::query("UPDATE items SET done = NOT done WHERE id = ?")
-        .bind(id)
-        .execute(db)
-        .await?;
-    Ok(())
-}
-
-pub async fn delete_item(db: &Pool<Sqlite>, id: i64) -> Result<()> {
-    tracing::trace!(item_id = id, "Deleting item");
-    sqlx::query("DELETE FROM items WHERE id = ?")
-        .bind(id)
-        .execute(db)
-        .await?;
-    Ok(())
-}
-
-pub async fn delete_all_items(db: &Pool<Sqlite>, chat_id: ChatId) -> Result<()> {
-    tracing::debug!(chat_id = chat_id.0, "Deleting all items");
-    sqlx::query("DELETE FROM items WHERE chat_id = ?")
-        .bind(chat_id.0)
-        .execute(db)
-        .await?;
-    Ok(())
-}
-
-pub async fn delete_items(db: &Pool<Sqlite>, ids: &[i64]) -> Result<()> {
-    tracing::trace!(?ids, "Deleting multiple items");
-    if ids.is_empty() {
-        return Ok(());
+impl Database {
+    pub async fn add_item(&self, chat_id: ChatId, text: &str) -> Result<()> {
+        tracing::trace!(chat_id = chat_id.0, text = %text, "Adding item");
+        sqlx::query("INSERT INTO items (chat_id, text) VALUES (?, ?)")
+            .bind(chat_id.0)
+            .bind(text)
+            .execute(self.pool())
+            .await?;
+        Ok(())
     }
 
-    let mut builder = sqlx::QueryBuilder::new("DELETE FROM items WHERE id IN (");
-    let mut separated = builder.separated(", ");
-    for id in ids {
-        separated.push_bind(id);
+    pub async fn list_items(&self, chat_id: ChatId) -> Result<Vec<Item>> {
+        tracing::trace!(chat_id = chat_id.0, "Listing items");
+        sqlx::query_as("SELECT id, text, done FROM items WHERE chat_id = ? ORDER BY id")
+            .bind(chat_id.0)
+            .fetch_all(self.pool())
+            .await
+            .map_err(Into::into)
     }
-    separated.push_unseparated(")");
-    builder.build().execute(db).await?;
-    Ok(())
+
+    pub async fn toggle_item(&self, id: i64) -> Result<()> {
+        tracing::trace!(item_id = id, "Toggling item");
+        sqlx::query("UPDATE items SET done = NOT done WHERE id = ?")
+            .bind(id)
+            .execute(self.pool())
+            .await?;
+        Ok(())
+    }
+
+    pub async fn delete_item(&self, id: i64) -> Result<()> {
+        tracing::trace!(item_id = id, "Deleting item");
+        sqlx::query("DELETE FROM items WHERE id = ?")
+            .bind(id)
+            .execute(self.pool())
+            .await?;
+        Ok(())
+    }
+
+    pub async fn delete_all_items(&self, chat_id: ChatId) -> Result<()> {
+        tracing::debug!(chat_id = chat_id.0, "Deleting all items");
+        sqlx::query("DELETE FROM items WHERE chat_id = ?")
+            .bind(chat_id.0)
+            .execute(self.pool())
+            .await?;
+        Ok(())
+    }
+
+    pub async fn delete_items(&self, ids: &[i64]) -> Result<()> {
+        tracing::trace!(?ids, "Deleting multiple items");
+        if ids.is_empty() {
+            return Ok(());
+        }
+
+        let mut builder = sqlx::QueryBuilder::new("DELETE FROM items WHERE id IN (");
+        let mut separated = builder.separated(", ");
+        for id in ids {
+            separated.push_bind(id);
+        }
+        separated.push_unseparated(")");
+        builder.build().execute(self.pool()).await?;
+        Ok(())
+    }
 }

--- a/src/handlers/delete.rs
+++ b/src/handlers/delete.rs
@@ -1,12 +1,12 @@
+use crate::db::Database;
 use anyhow::Result;
-use sqlx::{Pool, Sqlite};
 use std::collections::HashSet;
 use teloxide::{
     prelude::*,
     types::{ChatId, InlineKeyboardButton, InlineKeyboardMarkup, MessageId, UserId},
 };
 
-use crate::db::*;
+use crate::db::Item;
 
 use super::list::update_list_message;
 
@@ -39,7 +39,7 @@ pub fn format_delete_list(
     (text, InlineKeyboardMarkup::new(keyboard_buttons))
 }
 
-pub async fn enter_delete_mode(bot: Bot, msg: Message, db: &Pool<Sqlite>) -> Result<()> {
+pub async fn enter_delete_mode(bot: Bot, msg: Message, db: &Database) -> Result<()> {
     tracing::debug!(
         chat_id = msg.chat.id.0,
         user_id = msg.from.as_ref().map(|u| u.id.0),
@@ -47,7 +47,7 @@ pub async fn enter_delete_mode(bot: Bot, msg: Message, db: &Pool<Sqlite>) -> Res
     );
     let _ = bot.delete_message(msg.chat.id, msg.id).await;
 
-    if get_last_list_message_id(db, msg.chat.id).await?.is_none() {
+    if db.get_last_list_message_id(msg.chat.id).await?.is_none() {
         let sent_msg = bot
             .send_message(msg.chat.id, "There is no active list to edit.")
             .await?;
@@ -60,7 +60,7 @@ pub async fn enter_delete_mode(bot: Bot, msg: Message, db: &Pool<Sqlite>) -> Res
         None => return Ok(()),
     };
 
-    if let Some(prev) = get_delete_session(db, user.id.0 as i64).await? {
+    if let Some(prev) = db.get_delete_session(user.id.0 as i64).await? {
         if let Some((c, m)) = prev.notice {
             let _ = bot.delete_message(c, m).await;
         }
@@ -69,12 +69,13 @@ pub async fn enter_delete_mode(bot: Bot, msg: Message, db: &Pool<Sqlite>) -> Res
         }
     }
 
-    let items = list_items(db, msg.chat.id).await?;
+    let items = db.list_items(msg.chat.id).await?;
     if items.is_empty() {
         return Ok(());
     }
 
-    init_delete_session(db, user.id.0 as i64, msg.chat.id).await?;
+    db.init_delete_session(user.id.0 as i64, msg.chat.id)
+        .await?;
 
     let (base_text, keyboard) = { format_delete_list(&items, &HashSet::new()) };
 
@@ -91,7 +92,8 @@ pub async fn enter_delete_mode(bot: Bot, msg: Message, db: &Pool<Sqlite>) -> Res
         .await
     {
         Ok(dm_msg) => {
-            set_delete_dm_message(db, user.id.0 as i64, dm_msg.id).await?;
+            db.set_delete_dm_message(user.id.0 as i64, dm_msg.id)
+                .await?;
             if !msg.chat.is_private() {
                 let info = bot
                     .send_message(
@@ -99,7 +101,8 @@ pub async fn enter_delete_mode(bot: Bot, msg: Message, db: &Pool<Sqlite>) -> Res
                         format!("{} is selecting items to delete...", user.first_name),
                     )
                     .await?;
-                set_delete_notice(db, user.id.0 as i64, msg.chat.id, info.id).await?;
+                db.set_delete_notice(user.id.0 as i64, msg.chat.id, info.id)
+                    .await?;
             }
         }
         Err(err) => {
@@ -117,22 +120,21 @@ pub async fn enter_delete_mode(bot: Bot, msg: Message, db: &Pool<Sqlite>) -> Res
     Ok(())
 }
 
-pub async fn callback_handler(bot: Bot, q: CallbackQuery, db: Pool<Sqlite>) -> Result<()> {
+pub async fn callback_handler(bot: Bot, q: CallbackQuery, db: Database) -> Result<()> {
     if let (Some(data), Some(msg)) = (q.data, q.message) {
         if let Some(id_str) = data.strip_prefix("delete_") {
             let user_id = q.from.id.0 as i64;
 
             if id_str == "done" {
-                if let Some(session) = get_delete_session(&db, user_id).await? {
+                if let Some(session) = db.get_delete_session(user_id).await? {
                     if session.dm_message_id.map(|m| m.0) != Some(msg.id().0) {
                         return Ok(());
                     }
                     for id in &session.selected {
-                        delete_item(&db, *id).await?;
+                        db.delete_item(*id).await?;
                     }
 
-                    if let Some(main_list_id) =
-                        get_last_list_message_id(&db, session.chat_id).await?
+                    if let Some(main_list_id) = db.get_last_list_message_id(session.chat_id).await?
                     {
                         update_list_message(&bot, session.chat_id, MessageId(main_list_id), &db)
                             .await?;
@@ -142,12 +144,12 @@ pub async fn callback_handler(bot: Bot, q: CallbackQuery, db: Pool<Sqlite>) -> R
                         let _ = bot.delete_message(chat_id, notice_id).await;
                     }
 
-                    clear_delete_session(&db, user_id).await?;
+                    db.clear_delete_session(user_id).await?;
                 }
 
                 let _ = bot.delete_message(msg.chat().id, msg.id()).await;
             } else if let Ok(id) = id_str.parse::<i64>() {
-                if let Some(mut session) = get_delete_session(&db, user_id).await? {
+                if let Some(mut session) = db.get_delete_session(user_id).await? {
                     if session.dm_message_id.map(|m| m.0) != Some(msg.id().0) {
                         return Ok(());
                     }
@@ -156,8 +158,9 @@ pub async fn callback_handler(bot: Bot, q: CallbackQuery, db: Pool<Sqlite>) -> R
                     } else {
                         session.selected.insert(id);
                     }
-                    update_delete_selection(&db, user_id, &session.selected).await?;
-                    let items = list_items(&db, session.chat_id).await?;
+                    db.update_delete_selection(user_id, &session.selected)
+                        .await?;
+                    let items = db.list_items(session.chat_id).await?;
                     let (text, keyboard) = format_delete_list(&items, &session.selected);
                     let _ = bot
                         .edit_message_text(msg.chat().id, msg.id(), text)
@@ -166,7 +169,7 @@ pub async fn callback_handler(bot: Bot, q: CallbackQuery, db: Pool<Sqlite>) -> R
                 }
             }
         } else if let Ok(id) = data.parse::<i64>() {
-            toggle_item(&db, id).await?;
+            db.toggle_item(id).await?;
             update_list_message(&bot, msg.chat().id, msg.id(), &db).await?;
         }
     }

--- a/src/handlers/photo.rs
+++ b/src/handlers/photo.rs
@@ -1,6 +1,6 @@
+use crate::db::Database;
 use crate::utils::download_file;
 use anyhow::Result;
-use sqlx::{Pool, Sqlite};
 use teloxide::prelude::*;
 
 use crate::ai::vision::parse_photo_items;
@@ -12,7 +12,7 @@ use crate::ai::config::AiConfig;
 pub async fn add_items_from_photo(
     bot: Bot,
     msg: Message,
-    db: Pool<Sqlite>,
+    db: Database,
     ai_config: Option<AiConfig>,
 ) -> Result<()> {
     let Some(config) = ai_config else {

--- a/src/handlers/text.rs
+++ b/src/handlers/text.rs
@@ -1,5 +1,5 @@
+use crate::db::Database;
 use anyhow::Result;
-use sqlx::{Pool, Sqlite};
 use teloxide::prelude::*;
 
 use crate::ai::config::AiConfig;
@@ -28,7 +28,7 @@ pub async fn help(bot: Bot, msg: Message) -> Result<()> {
     Ok(())
 }
 
-pub async fn add_items_from_text(bot: Bot, msg: Message, db: Pool<Sqlite>) -> Result<()> {
+pub async fn add_items_from_text(bot: Bot, msg: Message, db: Database) -> Result<()> {
     if let Some(text) = msg.text() {
         let items: Vec<String> = text.lines().filter_map(parse_item_line).collect();
 
@@ -43,7 +43,7 @@ pub async fn add_items_from_text(bot: Bot, msg: Message, db: Pool<Sqlite>) -> Re
 pub async fn add_items_from_parsed_text(
     bot: Bot,
     msg: Message,
-    db: Pool<Sqlite>,
+    db: Database,
     ai_config: Option<AiConfig>,
 ) -> Result<()> {
     let Some(config) = ai_config else {

--- a/src/handlers/voice.rs
+++ b/src/handlers/voice.rs
@@ -1,20 +1,17 @@
+use crate::db::Database;
 use crate::utils::download_file;
 use anyhow::Result;
-use sqlx::{Pool, Sqlite};
 use teloxide::prelude::*;
 
 use crate::ai::config::AiConfig;
 use crate::ai::gpt::{interpret_voice_command, VoiceCommand};
 use crate::ai::stt::{parse_items, transcribe_audio, DEFAULT_PROMPT};
-#[cfg(test)]
-use crate::db::add_item;
-use crate::db::{delete_items, list_items};
 use crate::text_utils::{capitalize_first, normalize_for_match};
 
 use crate::db::Item;
 
 pub async fn delete_matching_items(
-    db: &Pool<Sqlite>,
+    db: &Database,
     current: &mut Vec<Item>,
     items: &[String],
 ) -> Result<Vec<String>> {
@@ -31,7 +28,7 @@ pub async fn delete_matching_items(
             deleted.push(found.text);
         }
     }
-    delete_items(db, &ids).await?;
+    db.delete_items(&ids).await?;
     Ok(deleted)
 }
 
@@ -40,7 +37,7 @@ use super::list::{insert_items, send_list};
 pub async fn add_items_from_voice(
     bot: Bot,
     msg: Message,
-    db: Pool<Sqlite>,
+    db: Database,
     ai_config: Option<AiConfig>,
 ) -> Result<()> {
     let Some(config) = ai_config else {
@@ -69,7 +66,7 @@ pub async fn add_items_from_voice(
                 tracing::debug!("voice transcription empty; ignoring");
                 return Ok(());
             }
-            let mut current = list_items(&db, msg.chat.id).await?;
+            let mut current = db.list_items(msg.chat.id).await?;
             let list_texts: Vec<String> = current.iter().map(|i| i.text.clone()).collect();
             match interpret_voice_command(&config.api_key, &config.gpt_model, &text, &list_texts)
                 .await
@@ -136,10 +133,10 @@ mod tests {
         let db = init_test_db().await;
         let chat = ChatId(1);
         for _ in 0..3 {
-            add_item(&db, chat, "Item").await.unwrap();
+            db.add_item(chat, "Item").await.unwrap();
         }
 
-        let mut current = list_items(&db, chat).await.unwrap();
+        let mut current = db.list_items(chat).await.unwrap();
         let deleted = delete_matching_items(
             &db,
             &mut current,
@@ -149,7 +146,7 @@ mod tests {
         .unwrap();
         assert_eq!(deleted.len(), 3);
         assert!(current.is_empty());
-        let remaining = list_items(&db, chat).await.unwrap();
+        let remaining = db.list_items(chat).await.unwrap();
         assert!(remaining.is_empty());
     }
 
@@ -157,11 +154,11 @@ mod tests {
     async fn delete_matching_partial() {
         let db = init_test_db().await;
         let chat = ChatId(1);
-        add_item(&db, chat, "Apple").await.unwrap();
-        add_item(&db, chat, "Banana").await.unwrap();
-        add_item(&db, chat, "Carrot").await.unwrap();
+        db.add_item(chat, "Apple").await.unwrap();
+        db.add_item(chat, "Banana").await.unwrap();
+        db.add_item(chat, "Carrot").await.unwrap();
 
-        let mut current = list_items(&db, chat).await.unwrap();
+        let mut current = db.list_items(chat).await.unwrap();
         let deleted = delete_matching_items(
             &db,
             &mut current,
@@ -174,7 +171,7 @@ mod tests {
         assert_eq!(current.len(), 1);
         assert_eq!(current[0].text, "Apple");
 
-        let remaining = list_items(&db, chat).await.unwrap();
+        let remaining = db.list_items(chat).await.unwrap();
         assert_eq!(remaining.len(), 1);
         assert_eq!(remaining[0].text, "Apple");
     }

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -1,7 +1,8 @@
-use sqlx::{sqlite::SqlitePoolOptions, Pool, Sqlite};
+use crate::db::Database;
+use sqlx::sqlite::SqlitePoolOptions;
 
-pub async fn init_test_db() -> Pool<Sqlite> {
-    let db = SqlitePoolOptions::new()
+pub async fn init_test_db() -> Database {
+    let pool = SqlitePoolOptions::new()
         .max_connections(1)
         .connect("sqlite::memory:")
         .await
@@ -10,23 +11,23 @@ pub async fn init_test_db() -> Pool<Sqlite> {
     sqlx::query(
         "CREATE TABLE items(\n    id INTEGER PRIMARY KEY AUTOINCREMENT,\n    chat_id INTEGER NOT NULL,\n    text TEXT NOT NULL,\n    done BOOLEAN NOT NULL DEFAULT 0\n)"
     )
-    .execute(&db)
+    .execute(&pool)
     .await
     .unwrap();
 
     sqlx::query(
         "CREATE TABLE chat_state(\n    chat_id INTEGER PRIMARY KEY,\n    last_list_message_id INTEGER\n)"
     )
-    .execute(&db)
+    .execute(&pool)
     .await
     .unwrap();
 
     sqlx::query(
         "CREATE TABLE delete_session(\n    user_id INTEGER PRIMARY KEY,\n    chat_id INTEGER NOT NULL,\n    selected TEXT NOT NULL DEFAULT '',\n    notice_chat_id INTEGER,\n    notice_message_id INTEGER,\n    dm_message_id INTEGER\n)"
     )
-    .execute(&db)
+    .execute(&pool)
     .await
     .unwrap();
 
-    db
+    Database::new(pool)
 }

--- a/tests/insert_items.rs
+++ b/tests/insert_items.rs
@@ -25,7 +25,7 @@ async fn insert_items_adds_and_sends() {
     assert_eq!(added, 1);
 
     let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM items")
-        .fetch_one(&db)
+        .fetch_one(&*db)
         .await
         .unwrap();
     assert_eq!(count.0, 1);
@@ -50,7 +50,7 @@ async fn insert_items_empty_sends_nothing() {
     assert_eq!(added, 0);
 
     let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM items")
-        .fetch_one(&db)
+        .fetch_one(&*db)
         .await
         .unwrap();
     assert_eq!(count.0, 0);


### PR DESCRIPTION
## Summary
- add `Database` wrapper around `Pool<Sqlite>`
- convert free functions in `db` modules to `Database` methods
- update handlers, library code and tests to use the new struct
- adjust integration tests to dereference `Database` when issuing raw SQL

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast -- --test-threads=1`

------
https://chatgpt.com/codex/tasks/task_e_684765410b94832dbf8f4491e3458331