### PR TITLE
Update changelog instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,8 +13,8 @@
   public crate API.
 - Avoid global state. Persist temporary data such as deletion selections and any notice messages in the database.
 - Keep the `migrations/` directory up to date whenever the database schema changes so that embedded migrations remain in sync.
-- Update `CHANGELOG.md` only for user-visible changes. Internal CI and tooling updates should not be listed. Keep pending changes under a `## Unreleased` section as a numbered list. When the project version is bumped, add a `## [version] - <date>` heading below `Unreleased` and continue the next list under `Unreleased`.
-- Release commits may update the manifest version to match the release's semver. After the release PR is merged, a maintainer tags that commit. The next PR should then bump the version to the next patch level and start a fresh `## Unreleased` section in `CHANGELOG.md`.
+- Update `CHANGELOG.md` only for user-visible changes. Internal CI and tooling updates should not be listed. Keep pending changes under a `## Unreleased` section as a numbered list. Only create a new `## [version] - <date>` heading when a release commit is prepared. After adding the version heading, continue the next list under `Unreleased`.
+- Release commits may update the manifest version to match the release's semver. After the release PR is merged, a maintainer tags that commit. The next PR should then bump the version to the next patch level and start a fresh `## Unreleased` section in `CHANGELOG.md`. The manifest version may show an unreleased patch (e.g., `0.3.1`), but the changes remain under `Unreleased` until the release commit is prepared.
 - When updating versions in manifests, increment the patch version.
 - This is a generic list bot. Avoid hardcoding references to "groceries" in prompts or logs. Use generic "items" wording instead.
 - Follow the modern Rust module layout: define a `name.rs` file alongside a


### PR DESCRIPTION
## Summary
- clarify how new version sections are created
- mention that Cargo.toml may show 0.3.1 but is unreleased until tagged

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`


------
https://chatgpt.com/codex/tasks/task_e_6847f4371218832da4616e6c47772600