### PR TITLE
Update docs for generic item handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@
 - Release commits may update the manifest version to match the release's semver. After the release PR is merged, a maintainer tags that commit. The next PR should then bump the version to the next patch level and start a fresh `## Unreleased` section in `CHANGELOG.md`.
 - When updating versions in manifests, increment the patch version.
 - This is a generic list bot. Avoid hardcoding references to "groceries" in prompts or logs. Use generic "items" wording instead.
+- The bot's historic name is "Vibe Grocery Bot", but documentation and code should still refer to items generically.
 - Follow the modern Rust module layout: define a `name.rs` file alongside a
   `name/` directory for submodules instead of using `mod.rs`.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **WARNING: THIS ENTIRE PROJECT WAS VIBECODED WITH ONLY HOMEOPATHIC HUMAN EDITS!**
 
-Vibe Grocery Bot is a small Telegram bot for managing a shared shopping list. Each chat—whether a group or a private conversation—gets its own independent list.
+Vibe Grocery Bot is a small Telegram bot for managing a shared list of items. Each chat—whether a group or a private conversation—gets its own independent list.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- clarify that Vibe Grocery Bot manages a generic list of items
- note the historical name in AGENTS guidelines

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`


------
https://chatgpt.com/codex/tasks/task_e_6847f442e894832da53c075ba4a63356