### PR TITLE
Improve bot API error logging

### DIFF
--- a/src/handlers/list_service.rs
+++ b/src/handlers/list_service.rs
@@ -22,7 +22,14 @@ impl<'a> ListService<'a> {
 
     pub async fn send_list(&self, bot: Bot, chat_id: ChatId) -> Result<()> {
         if let Some(msg_id) = self.db.get_last_list_message_id(chat_id).await? {
-            let _ = bot.delete_message(chat_id, MessageId(msg_id)).await;
+            if let Err(err) = bot.delete_message(chat_id, MessageId(msg_id)).await {
+                tracing::warn!(
+                    error = %err,
+                    chat_id = chat_id.0,
+                    message_id = msg_id,
+                    "Failed to delete message",
+                );
+            }
         }
 
         let items = self.db.list_items(chat_id).await?;
@@ -64,20 +71,36 @@ impl<'a> ListService<'a> {
     ) -> Result<()> {
         let items = self.db.list_items(chat_id).await?;
         if items.is_empty() {
-            let _ = bot
+            if let Err(err) = bot
                 .edit_message_text(chat_id, message_id, LIST_NOW_EMPTY)
                 .reply_markup(InlineKeyboardMarkup::new(
                     Vec::<Vec<InlineKeyboardButton>>::new(),
                 ))
-                .await;
+                .await
+            {
+                tracing::warn!(
+                    error = %err,
+                    chat_id = chat_id.0,
+                    message_id = message_id.0,
+                    "Failed to edit message",
+                );
+            }
             return Ok(());
         }
 
         let (text, keyboard) = format_list(&items);
-        let _ = bot
+        if let Err(err) = bot
             .edit_message_text(chat_id, message_id, text)
             .reply_markup(keyboard)
-            .await;
+            .await
+        {
+            tracing::warn!(
+                error = %err,
+                chat_id = chat_id.0,
+                message_id = message_id.0,
+                "Failed to edit message",
+            );
+        }
         Ok(())
     }
 
@@ -99,12 +122,20 @@ impl<'a> ListService<'a> {
         let (final_text, _) = format_list(&items);
         let archived_text = format!("{ARCHIVED_LIST_HEADER}\n{}", final_text);
 
-        let _ = bot
+        if let Err(err) = bot
             .edit_message_text(chat_id, MessageId(last_message_id), archived_text)
             .reply_markup(InlineKeyboardMarkup::new(
                 Vec::<Vec<InlineKeyboardButton>>::new(),
             ))
-            .await;
+            .await
+        {
+            tracing::warn!(
+                error = %err,
+                chat_id = chat_id.0,
+                message_id = last_message_id,
+                "Failed to edit message",
+            );
+        }
 
         self.db.delete_all_items(chat_id).await?;
         self.db.clear_last_list_message_id(chat_id).await?;
@@ -114,11 +145,26 @@ impl<'a> ListService<'a> {
     }
 
     pub async fn nuke(&self, bot: Bot, msg: Message) -> Result<()> {
-        let _ = bot.delete_message(msg.chat.id, msg.id).await;
+        if let Err(err) = bot.delete_message(msg.chat.id, msg.id).await {
+            tracing::warn!(
+                error = %err,
+                chat_id = msg.chat.id.0,
+                message_id = msg.id.0,
+                "Failed to delete message",
+            );
+        }
         if let Some(list_message_id) = self.db.get_last_list_message_id(msg.chat.id).await? {
-            let _ = bot
+            if let Err(err) = bot
                 .delete_message(msg.chat.id, MessageId(list_message_id))
-                .await;
+                .await
+            {
+                tracing::warn!(
+                    error = %err,
+                    chat_id = msg.chat.id.0,
+                    message_id = list_message_id,
+                    "Failed to delete message",
+                );
+            }
         }
         self.db.delete_all_items(msg.chat.id).await?;
         self.db.clear_last_list_message_id(msg.chat.id).await?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -16,7 +16,14 @@ pub fn delete_after(bot: Bot, chat_id: ChatId, message_id: MessageId, secs: u64)
     );
     tokio::spawn(async move {
         tokio::time::sleep(std::time::Duration::from_secs(secs)).await;
-        let _ = bot.delete_message(chat_id, message_id).await;
+        if let Err(err) = bot.delete_message(chat_id, message_id).await {
+            tracing::warn!(
+                error = %err,
+                chat_id = chat_id.0,
+                message_id = message_id.0,
+                "Failed to delete message",
+            );
+        }
     });
 }
 


### PR DESCRIPTION
## Summary
- log failures when deleting or editing messages
- surface API errors in delete mode helpers
- surface API errors in list service helpers

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`


------
https://chatgpt.com/codex/tasks/task_e_6847f445a25c832d902e2eb745e65cd5