### PR TITLE
Enforce chat-specific item actions

### DIFF
--- a/src/handlers/delete.rs
+++ b/src/handlers/delete.rs
@@ -148,7 +148,7 @@ pub async fn callback_handler(bot: Bot, q: CallbackQuery, db: Database) -> Resul
                         return Ok(());
                     }
                     for id in &session.selected {
-                        db.delete_item(*id).await?;
+                        db.delete_item(session.chat_id, *id).await?;
                     }
 
                     if let Some(main_list_id) = db.get_last_list_message_id(session.chat_id).await?
@@ -208,7 +208,7 @@ pub async fn callback_handler(bot: Bot, q: CallbackQuery, db: Database) -> Resul
                 }
             }
         } else if let Ok(id) = data.parse::<i64>() {
-            db.toggle_item(id).await?;
+            db.toggle_item(msg.chat().id, id).await?;
             update_list_message(&bot, msg.chat().id, msg.id(), &db).await?;
         }
     }

--- a/src/handlers/voice.rs
+++ b/src/handlers/voice.rs
@@ -13,6 +13,7 @@ use crate::db::Item;
 
 pub async fn delete_matching_items(
     db: &Database,
+    chat_id: ChatId,
     current: &mut Vec<Item>,
     items: &[String],
 ) -> Result<Vec<String>> {
@@ -29,7 +30,7 @@ pub async fn delete_matching_items(
             deleted.push(found.text);
         }
     }
-    db.delete_items(&ids).await?;
+    db.delete_items(chat_id, &ids).await?;
     Ok(deleted)
 }
 
@@ -85,7 +86,8 @@ pub async fn add_items_from_voice(
                     }
                 }
                 Ok(VoiceCommand::Delete(items)) => {
-                    let deleted = delete_matching_items(&db, &mut current, &items).await?;
+                    let deleted =
+                        delete_matching_items(&db, msg.chat.id, &mut current, &items).await?;
                     if !deleted.is_empty() {
                         tracing::info!(
                             "Deleted {} item(s) via voice for chat {}",
@@ -139,6 +141,7 @@ mod tests {
         let mut current = db.list_items(chat).await.unwrap();
         let deleted = delete_matching_items(
             &db,
+            chat,
             &mut current,
             &["Item".to_string(), "Item".to_string(), "Item".to_string()],
         )
@@ -161,6 +164,7 @@ mod tests {
         let mut current = db.list_items(chat).await.unwrap();
         let deleted = delete_matching_items(
             &db,
+            chat,
             &mut current,
             &["Banana".to_string(), "Carrot".to_string()],
         )

--- a/tests/cross_chat.rs
+++ b/tests/cross_chat.rs
@@ -1,0 +1,45 @@
+use shopbot::tests::util::init_test_db;
+use teloxide::types::ChatId;
+
+#[tokio::test]
+async fn toggle_different_chat_has_no_effect() {
+    let db = init_test_db().await;
+    let chat1 = ChatId(1);
+    let chat2 = ChatId(2);
+    db.add_item(chat1, "Milk").await.unwrap();
+
+    let item = db.list_items(chat1).await.unwrap()[0].clone();
+    db.toggle_item(chat2, item.id).await.unwrap();
+
+    let after = db.list_items(chat1).await.unwrap()[0].clone();
+    assert!(!after.done);
+}
+
+#[tokio::test]
+async fn delete_different_chat_has_no_effect() {
+    let db = init_test_db().await;
+    let chat1 = ChatId(1);
+    let chat2 = ChatId(2);
+    db.add_item(chat1, "Milk").await.unwrap();
+    let item = db.list_items(chat1).await.unwrap()[0].clone();
+
+    db.delete_item(chat2, item.id).await.unwrap();
+    let remaining = db.list_items(chat1).await.unwrap();
+    assert_eq!(remaining.len(), 1);
+}
+
+#[tokio::test]
+async fn delete_multiple_different_chat_has_no_effect() {
+    let db = init_test_db().await;
+    let chat1 = ChatId(1);
+    let chat2 = ChatId(2);
+    for _ in 0..3 {
+        db.add_item(chat1, "Item").await.unwrap();
+    }
+    let items = db.list_items(chat1).await.unwrap();
+    let ids: Vec<i64> = items.iter().map(|i| i.id).collect();
+
+    db.delete_items(chat2, &ids).await.unwrap();
+    let remaining = db.list_items(chat1).await.unwrap();
+    assert_eq!(remaining.len(), 3);
+}

--- a/tests/db_flow.rs
+++ b/tests/db_flow.rs
@@ -15,11 +15,11 @@ async fn basic_item_flow() -> Result<()> {
     assert_eq!(items[0].text, "Apples");
     assert!(!items[0].done);
 
-    db.toggle_item(items[0].id).await?;
+    db.toggle_item(chat, items[0].id).await?;
     items = db.list_items(chat).await?;
     assert!(items[0].done);
 
-    db.delete_item(items[1].id).await?;
+    db.delete_item(chat, items[1].id).await?;
     items = db.list_items(chat).await?;
     assert_eq!(items.len(), 1);
 


### PR DESCRIPTION
## Summary
- prevent toggling or deleting items across chats
- update callback and voice handlers to pass chat id
- add tests covering cross-chat isolation

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`


------
https://chatgpt.com/codex/tasks/task_e_6847ff4bb9d4832d9ffea64077e6ea00