### PR TITLE
Improve Unicode handling for capitalize_first

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2220,6 +2220,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "unicode-segmentation",
  "wiremock",
 ]
 
@@ -2982,6 +2983,12 @@ name = "unicode-properties"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ serde_json = "1"
 futures-util = "0.3"
 base64 = "0.22"
 git-version = "0.3"
+unicode-segmentation = "1.12"
 
 [dev-dependencies]
 proptest = "1.7"

--- a/src/text_utils.rs
+++ b/src/text_utils.rs
@@ -31,10 +31,18 @@ pub fn parse_item_line(line: &str) -> Option<String> {
     }
 }
 
+use unicode_segmentation::UnicodeSegmentation;
+
 pub fn capitalize_first(text: &str) -> String {
-    let mut chars = text.chars();
-    match chars.next() {
-        Some(c) => c.to_uppercase().chain(chars).collect(),
+    let mut graphemes = text.graphemes(true);
+    match graphemes.next() {
+        Some(first) => {
+            let mut result = first.to_uppercase();
+            for g in graphemes {
+                result.push_str(g);
+            }
+            result
+        }
         None => String::new(),
     }
 }
@@ -51,4 +59,19 @@ pub fn normalize_for_match(text: &str) -> String {
     let result = trimmed.to_lowercase();
     trace!(original = %text, normalized = %result, "normalized for match");
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn capitalize_accented() {
+        assert_eq!(capitalize_first("éclair"), "Éclair");
+    }
+
+    #[test]
+    fn capitalize_with_emoji() {
+        assert_eq!(capitalize_first("🍎 apple"), "🍎 apple");
+    }
 }


### PR DESCRIPTION
## Summary
- add `unicode-segmentation` crate
- support grapheme-aware capitalization
- test emoji and accented characters

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`


------
https://chatgpt.com/codex/tasks/task_e_6847feb757f0832dae99bbec41945858