### PR TITLE
Use constant for delete timeout

### DIFF
--- a/src/handlers/delete.rs
+++ b/src/handlers/delete.rs
@@ -62,7 +62,12 @@ pub async fn enter_delete_mode(bot: Bot, msg: Message, db: &Database) -> Result<
         let sent_msg = bot
             .send_message(msg.chat.id, NO_ACTIVE_LIST_TO_EDIT)
             .await?;
-        crate::delete_after(bot.clone(), sent_msg.chat.id, sent_msg.id, 5);
+        crate::delete_after(
+            bot.clone(),
+            sent_msg.chat.id,
+            sent_msg.id,
+            crate::utils::DELETE_AFTER_TIMEOUT,
+        );
         return Ok(());
     }
 
@@ -130,7 +135,12 @@ pub async fn enter_delete_mode(bot: Bot, msg: Message, db: &Database) -> Result<
         Err(err) => {
             tracing::warn!("failed to send DM: {}", err);
             let warn = bot.send_message(msg.chat.id, DELETE_DM_FAILED).await?;
-            crate::delete_after(bot.clone(), warn.chat.id, warn.id, 5);
+            crate::delete_after(
+                bot.clone(),
+                warn.chat.id,
+                warn.id,
+                crate::utils::DELETE_AFTER_TIMEOUT,
+            );
         }
     }
 

--- a/src/handlers/list_service.rs
+++ b/src/handlers/list_service.rs
@@ -169,7 +169,12 @@ impl<'a> ListService<'a> {
         self.db.delete_all_items(msg.chat.id).await?;
         self.db.clear_last_list_message_id(msg.chat.id).await?;
         let confirmation = bot.send_message(msg.chat.id, LIST_NUKED).await?;
-        crate::delete_after(bot.clone(), confirmation.chat.id, confirmation.id, 5);
+        crate::delete_after(
+            bot.clone(),
+            confirmation.chat.id,
+            confirmation.id,
+            crate::utils::DELETE_AFTER_TIMEOUT,
+        );
         Ok(())
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,6 +6,9 @@ use teloxide::{
     RequestError,
 };
 
+/// Default timeout in seconds for temporary messages.
+pub const DELETE_AFTER_TIMEOUT: u64 = 5;
+
 /// Delete a message after the given delay in seconds.
 pub fn delete_after(bot: Bot, chat_id: ChatId, message_id: MessageId, secs: u64) {
     tracing::debug!(


### PR DESCRIPTION
## Summary
- add `DELETE_AFTER_TIMEOUT` constant in `utils`
- use the new constant in the delete and list handlers

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`


------
https://chatgpt.com/codex/tasks/task_e_684822fca8fc832d9d66d7e5b4cec084