### PR TITLE
Add DB_POOL_SIZE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 1. Add index on `items.chat_id` to speed up queries.
 2. Vision model configurable via `OPENAI_VISION_MODEL`.
+3. Database pool size configurable via `DB_POOL_SIZE`.
 
 ## [0.3.0] - 2025-06-09
 1. `/info` command shows commit hash and release version or how many commits the build is ahead of the latest release

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Set these environment variables before running:
 
 - `TELOXIDE_TOKEN` – Telegram bot token from @BotFather
 - `DB_URL` – optional SQLite connection string (defaults to `sqlite:shopping.db`)
+- `DB_POOL_SIZE` – optional maximum number of SQLite connections (defaults to `5`)
 - `RUST_LOG` – optional logging level (e.g. `info` or `debug`)
 - `OPENAI_API_KEY` – optional API key for enabling voice and photo recognition
 - `OPENAI_STT_MODEL` – optional model name (`whisper-1`, `gpt-4o-mini-transcribe`, or `gpt-4o-transcribe`)

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,7 @@ use crate::ai::config::AiConfig;
 #[derive(Clone)]
 pub struct Config {
     pub db_url: String,
+    pub db_pool_size: u32,
     pub ai: Option<AiConfig>,
 }
 
@@ -12,7 +13,15 @@ impl Config {
     pub fn from_env() -> Self {
         dotenvy::dotenv().ok();
         let db_url = env::var("DB_URL").unwrap_or_else(|_| "sqlite:shopping.db".to_string());
+        let db_pool_size = env::var("DB_POOL_SIZE")
+            .ok()
+            .and_then(|s| s.parse::<u32>().ok())
+            .unwrap_or(5);
         let ai = AiConfig::from_env();
-        Self { db_url, ai }
+        Self {
+            db_url,
+            db_pool_size,
+            ai,
+        }
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -24,10 +24,10 @@ pub fn prepare_sqlite_url(url: &str) -> String {
     }
 }
 
-pub async fn connect_db(db_url: &str) -> Result<Pool<Sqlite>> {
-    tracing::debug!(db_url = %db_url, "Connecting to database");
+pub async fn connect_db(db_url: &str, pool_size: u32) -> Result<Pool<Sqlite>> {
+    tracing::debug!(db_url = %db_url, pool_size, "Connecting to database");
     Ok(SqlitePoolOptions::new()
-        .max_connections(5)
+        .max_connections(pool_size)
         .connect(db_url)
         .await?)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ pub async fn run() -> Result<()> {
 
     tracing::info!("Connecting to database at: {}", &db_url);
 
-    let pool = db::connect_db(&db_url).await?;
+    let pool = db::connect_db(&db_url, config.db_pool_size).await?;
     let db = db::Database::new(pool);
 
     tracing::info!("Database connection successful.");

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -1,10 +1,7 @@
-use crate::db::Database;
-use sqlx::sqlite::SqlitePoolOptions;
+use crate::db::{connect_db, Database};
 
 pub async fn init_test_db() -> Database {
-    let pool = SqlitePoolOptions::new()
-        .max_connections(1)
-        .connect("sqlite::memory:")
+    let pool = connect_db("sqlite::memory:", 1)
         .await
         .expect("failed to create in-memory database");
 

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -44,13 +44,26 @@ fn ai_config_from_env_custom_models() {
 #[serial]
 fn config_from_env_calls_ai_constructor() {
     std::env::set_var("DB_URL", "db");
+    std::env::remove_var("DB_POOL_SIZE");
     std::env::set_var("OPENAI_API_KEY", "k");
     std::env::remove_var("OPENAI_STT_MODEL");
     std::env::remove_var("OPENAI_GPT_MODEL");
     std::env::remove_var("OPENAI_VISION_MODEL");
     let cfg = Config::from_env();
     assert_eq!(cfg.db_url, "db");
+    assert_eq!(cfg.db_pool_size, 5);
     let ai = cfg.ai.unwrap();
     assert_eq!(ai.api_key, "k");
     assert_eq!(ai.stt_model, "whisper-1");
+}
+
+#[test]
+#[serial]
+fn config_from_env_custom_pool_size() {
+    std::env::set_var("DB_URL", "db");
+    std::env::set_var("DB_POOL_SIZE", "2");
+    std::env::remove_var("OPENAI_API_KEY");
+    let cfg = Config::from_env();
+    assert_eq!(cfg.db_pool_size, 2);
+    assert!(cfg.ai.is_none());
 }


### PR DESCRIPTION
## Summary
- allow configuring DB pool size via `DB_POOL_SIZE`
- use the setting when connecting to the database
- mention the variable in the README and changelog
- ensure tests initialize a small pool

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`

------
https://chatgpt.com/codex/tasks/task_e_68482c4465ec832d94f018b1b0a009f7