### PR TITLE
Add configurable OpenAI endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 1. Add index on `items.chat_id` to speed up queries.
 2. Vision model configurable via `OPENAI_VISION_MODEL`.
+3. Custom OpenAI endpoints via `OPENAI_CHAT_URL` and `OPENAI_STT_URL`.
 
 ## [0.3.0] - 2025-06-09
 1. `/info` command shows commit hash and release version or how many commits the build is ahead of the latest release

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Set these environment variables before running:
 - `OPENAI_STT_MODEL` – optional model name (`whisper-1`, `gpt-4o-mini-transcribe`, or `gpt-4o-transcribe`)
 - `OPENAI_GPT_MODEL` – optional chat model name (defaults to `gpt-4.1`)
 - `OPENAI_VISION_MODEL` – optional vision model name (defaults to `gpt-4o`)
+- `OPENAI_CHAT_URL` – optional URL for the chat completion API
+- `OPENAI_STT_URL` – optional URL for the transcription API
 
 The database file is created automatically if needed. Embedded SQLx migrations in the `migrations/` directory are executed on startup.
 

--- a/src/ai/config.rs
+++ b/src/ai/config.rs
@@ -5,6 +5,8 @@ pub struct AiConfig {
     pub stt_model: String,
     pub gpt_model: String,
     pub vision_model: String,
+    pub openai_chat_url: Option<String>,
+    pub openai_stt_url: Option<String>,
 }
 
 impl AiConfig {
@@ -18,6 +20,8 @@ impl AiConfig {
             stt_model: env::var("OPENAI_STT_MODEL").unwrap_or_else(|_| "whisper-1".to_string()),
             gpt_model: env::var("OPENAI_GPT_MODEL").unwrap_or_else(|_| "gpt-4.1".to_string()),
             vision_model: env::var("OPENAI_VISION_MODEL").unwrap_or_else(|_| "gpt-4o".to_string()),
+            openai_chat_url: env::var("OPENAI_CHAT_URL").ok(),
+            openai_stt_url: env::var("OPENAI_STT_URL").ok(),
         })
     }
 }

--- a/src/ai/gpt.rs
+++ b/src/ai/gpt.rs
@@ -49,8 +49,10 @@ pub async fn interpret_voice_command(
     model: &str,
     text: &str,
     list: &[String],
+    url: Option<&str>,
 ) -> Result<VoiceCommand> {
-    interpret_voice_command_inner(api_key, model, text, list, OPENAI_CHAT_URL).await
+    let url = url.unwrap_or(OPENAI_CHAT_URL);
+    interpret_voice_command_inner(api_key, model, text, list, url).await
 }
 
 #[cfg_attr(not(test), allow(dead_code))]

--- a/src/ai/stt.rs
+++ b/src/ai/stt.rs
@@ -15,7 +15,7 @@ struct TranscriptionResponse {
     text: String,
 }
 
-const OPENAI_URL: &str = "https://api.openai.com/v1/audio/transcriptions";
+const OPENAI_STT_URL: &str = "https://api.openai.com/v1/audio/transcriptions";
 
 #[instrument(level = "trace", skip(api_key, bytes))]
 async fn transcribe_audio_inner(
@@ -52,7 +52,7 @@ pub async fn transcribe_audio(
     bytes: &[u8],
     url: Option<&str>,
 ) -> Result<String> {
-    let url = url.unwrap_or(OPENAI_URL);
+    let url = url.unwrap_or(OPENAI_STT_URL);
     transcribe_audio_inner(model, api_key, prompt, bytes, url).await
 }
 

--- a/src/handlers/photo.rs
+++ b/src/handlers/photo.rs
@@ -37,7 +37,14 @@ pub async fn add_items_from_photo(
     tracing::trace!(size = bytes.len(), "downloaded photo bytes");
 
     tracing::debug!(model = %config.vision_model, "parsing photo with OpenAI vision");
-    let items = match parse_photo_items(&config.api_key, &config.vision_model, &bytes, None).await {
+    let items = match parse_photo_items(
+        &config.api_key,
+        &config.vision_model,
+        &bytes,
+        config.openai_chat_url.as_deref(),
+    )
+    .await
+    {
         Ok(list) => list,
         Err(err) => {
             tracing::warn!("photo parsing failed: {}", err);
@@ -74,6 +81,8 @@ mod tests {
             stt_model: "m".into(),
             gpt_model: "g".into(),
             vision_model: "v".into(),
+            openai_chat_url: None,
+            openai_stt_url: None,
         });
 
         let res = add_items_from_photo(bot, msg, db, ai_config).await;

--- a/src/handlers/text.rs
+++ b/src/handlers/text.rs
@@ -44,7 +44,14 @@ pub async fn add_items_from_parsed_text(
         return Ok(());
     };
 
-    let items = match parse_items_gpt(&config.api_key, &config.gpt_model, text, None).await {
+    let items = match parse_items_gpt(
+        &config.api_key,
+        &config.gpt_model,
+        text,
+        config.openai_chat_url.as_deref(),
+    )
+    .await
+    {
         Ok(list) => list,
         Err(err) => {
             tracing::warn!("gpt parsing failed: {}", err);

--- a/src/handlers/voice.rs
+++ b/src/handlers/voice.rs
@@ -59,7 +59,7 @@ pub async fn add_items_from_voice(
         &config.api_key,
         Some(DEFAULT_PROMPT),
         &audio,
-        None,
+        config.openai_stt_url.as_deref(),
     )
     .await
     {
@@ -70,8 +70,14 @@ pub async fn add_items_from_voice(
             }
             let mut current = db.list_items(msg.chat.id).await?;
             let list_texts: Vec<String> = current.iter().map(|i| i.text.clone()).collect();
-            match interpret_voice_command(&config.api_key, &config.gpt_model, &text, &list_texts)
-                .await
+            match interpret_voice_command(
+                &config.api_key,
+                &config.gpt_model,
+                &text,
+                &list_texts,
+                config.openai_chat_url.as_deref(),
+            )
+            .await
             {
                 Ok(VoiceCommand::Add(items)) => {
                     let items: Vec<String> =

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -20,11 +20,15 @@ fn ai_config_from_env_defaults() {
     std::env::remove_var("OPENAI_STT_MODEL");
     std::env::remove_var("OPENAI_GPT_MODEL");
     std::env::remove_var("OPENAI_VISION_MODEL");
+    std::env::remove_var("OPENAI_CHAT_URL");
+    std::env::remove_var("OPENAI_STT_URL");
     let cfg = AiConfig::from_env().unwrap();
     assert_eq!(cfg.api_key, "k");
     assert_eq!(cfg.stt_model, "whisper-1");
     assert_eq!(cfg.gpt_model, "gpt-4.1");
     assert_eq!(cfg.vision_model, "gpt-4o");
+    assert!(cfg.openai_chat_url.is_none());
+    assert!(cfg.openai_stt_url.is_none());
 }
 
 #[test]
@@ -34,10 +38,26 @@ fn ai_config_from_env_custom_models() {
     std::env::set_var("OPENAI_STT_MODEL", "s");
     std::env::set_var("OPENAI_GPT_MODEL", "g");
     std::env::set_var("OPENAI_VISION_MODEL", "v");
+    std::env::remove_var("OPENAI_CHAT_URL");
+    std::env::remove_var("OPENAI_STT_URL");
     let cfg = AiConfig::from_env().unwrap();
     assert_eq!(cfg.stt_model, "s");
     assert_eq!(cfg.gpt_model, "g");
     assert_eq!(cfg.vision_model, "v");
+}
+
+#[test]
+#[serial]
+fn ai_config_from_env_custom_urls() {
+    std::env::set_var("OPENAI_API_KEY", "k");
+    std::env::remove_var("OPENAI_STT_MODEL");
+    std::env::remove_var("OPENAI_GPT_MODEL");
+    std::env::remove_var("OPENAI_VISION_MODEL");
+    std::env::set_var("OPENAI_CHAT_URL", "http://chat");
+    std::env::set_var("OPENAI_STT_URL", "http://stt");
+    let cfg = AiConfig::from_env().unwrap();
+    assert_eq!(cfg.openai_chat_url.as_deref(), Some("http://chat"));
+    assert_eq!(cfg.openai_stt_url.as_deref(), Some("http://stt"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- support `OPENAI_CHAT_URL` and `OPENAI_STT_URL` in `AiConfig`
- use optional endpoints throughout handlers
- document the new variables
- test endpoint parsing

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`

------
https://chatgpt.com/codex/tasks/task_e_68482c778a5c832d9063ec7a0691d374