### PR TITLE
Return JoinHandle from delete_after

### DIFF
--- a/src/handlers/delete.rs
+++ b/src/handlers/delete.rs
@@ -62,12 +62,12 @@ pub async fn enter_delete_mode(bot: Bot, msg: Message, db: &Database) -> Result<
         let sent_msg = bot
             .send_message(msg.chat.id, NO_ACTIVE_LIST_TO_EDIT)
             .await?;
-        crate::delete_after(
+        drop(crate::delete_after(
             bot.clone(),
             sent_msg.chat.id,
             sent_msg.id,
             crate::utils::DELETE_AFTER_TIMEOUT,
-        );
+        ));
         return Ok(());
     }
 
@@ -135,12 +135,12 @@ pub async fn enter_delete_mode(bot: Bot, msg: Message, db: &Database) -> Result<
         Err(err) => {
             tracing::warn!("failed to send DM: {}", err);
             let warn = bot.send_message(msg.chat.id, DELETE_DM_FAILED).await?;
-            crate::delete_after(
+            drop(crate::delete_after(
                 bot.clone(),
                 warn.chat.id,
                 warn.id,
                 crate::utils::DELETE_AFTER_TIMEOUT,
-            );
+            ));
         }
     }
 

--- a/src/handlers/list_service.rs
+++ b/src/handlers/list_service.rs
@@ -169,12 +169,12 @@ impl<'a> ListService<'a> {
         self.db.delete_all_items(msg.chat.id).await?;
         self.db.clear_last_list_message_id(msg.chat.id).await?;
         let confirmation = bot.send_message(msg.chat.id, LIST_NUKED).await?;
-        crate::delete_after(
+        drop(crate::delete_after(
             bot.clone(),
             confirmation.chat.id,
             confirmation.id,
             crate::utils::DELETE_AFTER_TIMEOUT,
-        );
+        ));
         Ok(())
     }
 }

--- a/tests/delete_utils.rs
+++ b/tests/delete_utils.rs
@@ -17,7 +17,7 @@ async fn test_delete_after_sends_request() {
         .await;
 
     let bot = Bot::new("TEST").set_api_url(reqwest::Url::parse(&server.uri()).unwrap());
-    delete_after(bot, ChatId(1), MessageId(2), 0);
-    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    let handle = delete_after(bot, ChatId(1), MessageId(2), 0);
+    handle.await.unwrap();
     server.verify().await;
 }


### PR DESCRIPTION
## Summary
- allow awaiting the `delete_after` task by returning a `JoinHandle`
- log when the spawned task finishes
- drop JoinHandles at call sites
- adjust unit test for new return type

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`

------
https://chatgpt.com/codex/tasks/task_e_68482c6e3fd8832da351f544e9184df6