### PR TITLE
Add environment example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,35 @@
+# Example environment configuration. Copy this file to `.env` and adjust the values.
+#
+# Values marked as optional may be omitted. Defaults are shown in comments.
+
+# Telegram bot token from @BotFather (required)
+TELOXIDE_TOKEN=
+
+# SQLite connection string (optional, defaults to "sqlite:shopping.db")
+# Use "sqlite:///data/shopping.db" when deploying on Fly.io
+DB_URL=sqlite:shopping.db
+
+# Maximum number of SQLite connections (optional, defaults to "5")
+DB_POOL_SIZE=5
+
+# Logging level such as "info" or "debug" (optional)
+RUST_LOG=info
+
+# OpenAI API key for voice and photo recognition (optional)
+OPENAI_API_KEY=
+
+# Speech-to-text model name (optional, defaults to "whisper-1")
+OPENAI_STT_MODEL=whisper-1
+
+# Chat model name (optional, defaults to "gpt-4.1")
+OPENAI_GPT_MODEL=gpt-4.1
+
+# Vision model name (optional, defaults to "gpt-4o")
+OPENAI_VISION_MODEL=gpt-4o
+
+# URL for the chat completion API (optional)
+OPENAI_CHAT_URL=
+
+# URL for the transcription API (optional)
+OPENAI_STT_URL=
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 2. Vision model configurable via `OPENAI_VISION_MODEL`.
 3. Custom OpenAI endpoints via `OPENAI_CHAT_URL` and `OPENAI_STT_URL`.
 4. Database pool size configurable via `DB_POOL_SIZE`.
+5. Example environment file `.env.example` documents all config variables.
 
 ## [0.3.0] - 2025-06-09
 1. `/info` command shows commit hash and release version or how many commits the build is ahead of the latest release

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Set these environment variables before running:
 - `OPENAI_CHAT_URL` – optional URL for the chat completion API
 - `OPENAI_STT_URL` – optional URL for the transcription API
 
-The database file is created automatically if needed. Embedded SQLx migrations in the `migrations/` directory are executed on startup.
+The database file is created automatically if needed. Embedded SQLx migrations in the `migrations/` directory are executed on startup. When deploying on Fly.io, set `DB_URL` to `sqlite:///data/shopping.db` to match `fly.toml`.
 
 ## Running
 


### PR DESCRIPTION
## Summary
- add `.env.example` describing config variables
- note correct DB_URL path for Fly.io deploys

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`


------
https://chatgpt.com/codex/tasks/task_e_684869e238a0832db7acc9d1175e4fdb