### PR TITLE
Make delete-after timeout configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,9 @@ DB_URL=sqlite:shopping.db
 # Maximum number of SQLite connections (optional, defaults to "5")
 DB_POOL_SIZE=5
 
+# Delay before temporary messages are deleted in seconds (optional, defaults to "5")
+DELETE_AFTER_TIMEOUT=5
+
 # Logging level such as "info" or "debug" (optional)
 RUST_LOG=info
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 3. Custom OpenAI endpoints via `OPENAI_CHAT_URL` and `OPENAI_STT_URL`.
 4. Database pool size configurable via `DB_POOL_SIZE`.
 5. Example environment file `.env.example` documents all config variables.
+6. Temporary message timeout configurable via `DELETE_AFTER_TIMEOUT`.
 
 ## [0.3.0] - 2025-06-09
 1. `/info` command shows commit hash and release version or how many commits the build is ahead of the latest release

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Set these environment variables before running:
 - `TELOXIDE_TOKEN` – Telegram bot token from @BotFather
 - `DB_URL` – optional SQLite connection string (defaults to `sqlite:shopping.db`)
 - `DB_POOL_SIZE` – optional maximum number of SQLite connections (defaults to `5`)
+- `DELETE_AFTER_TIMEOUT` – optional delay in seconds before temporary messages are deleted (defaults to `5`)
 - `RUST_LOG` – optional logging level (e.g. `info` or `debug`)
 - `OPENAI_API_KEY` – optional API key for enabling voice and photo recognition
 - `OPENAI_STT_MODEL` – optional model name (`whisper-1`, `gpt-4o-mini-transcribe`, or `gpt-4o-transcribe`)

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,7 @@ pub struct Config {
     pub db_url: String,
     pub db_pool_size: u32,
     pub ai: Option<AiConfig>,
+    pub delete_after_timeout: u64,
 }
 
 impl Config {
@@ -17,11 +18,16 @@ impl Config {
             .ok()
             .and_then(|s| s.parse::<u32>().ok())
             .unwrap_or(5);
+        let delete_after_timeout = env::var("DELETE_AFTER_TIMEOUT")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(crate::utils::DEFAULT_DELETE_AFTER_TIMEOUT);
         let ai = AiConfig::from_env();
         Self {
             db_url,
             db_pool_size,
             ai,
+            delete_after_timeout,
         }
     }
 }

--- a/src/handlers/delete.rs
+++ b/src/handlers/delete.rs
@@ -43,7 +43,12 @@ pub fn format_delete_list(
     (text, InlineKeyboardMarkup::new(keyboard_buttons))
 }
 
-pub async fn enter_delete_mode(bot: Bot, msg: Message, db: &Database) -> Result<()> {
+pub async fn enter_delete_mode(
+    bot: Bot,
+    msg: Message,
+    db: &Database,
+    delete_after_timeout: u64,
+) -> Result<()> {
     tracing::debug!(
         chat_id = msg.chat.id.0,
         user_id = msg.from.as_ref().map(|u| u.id.0),
@@ -66,7 +71,7 @@ pub async fn enter_delete_mode(bot: Bot, msg: Message, db: &Database) -> Result<
             bot.clone(),
             sent_msg.chat.id,
             sent_msg.id,
-            crate::utils::DELETE_AFTER_TIMEOUT,
+            delete_after_timeout,
         ));
         return Ok(());
     }
@@ -139,7 +144,7 @@ pub async fn enter_delete_mode(bot: Bot, msg: Message, db: &Database) -> Result<
                 bot.clone(),
                 warn.chat.id,
                 warn.id,
-                crate::utils::DELETE_AFTER_TIMEOUT,
+                delete_after_timeout,
             ));
         }
     }

--- a/src/handlers/list.rs
+++ b/src/handlers/list.rs
@@ -74,9 +74,16 @@ pub async fn archive(bot: Bot, chat_id: ChatId, db: &Database) -> Result<()> {
     ListService::new(db).archive(bot, chat_id).await
 }
 
-pub async fn nuke_list(bot: Bot, msg: Message, db: &Database) -> Result<()> {
+pub async fn nuke_list(
+    bot: Bot,
+    msg: Message,
+    db: &Database,
+    delete_after_timeout: u64,
+) -> Result<()> {
     tracing::debug!(chat_id = msg.chat.id.0, "Nuking list");
-    ListService::new(db).nuke(bot, msg).await
+    ListService::new(db)
+        .nuke(bot, msg, delete_after_timeout)
+        .await
 }
 
 pub async fn insert_items<I>(bot: Bot, chat_id: ChatId, db: &Database, items: I) -> Result<usize>

--- a/src/handlers/list_service.rs
+++ b/src/handlers/list_service.rs
@@ -144,7 +144,7 @@ impl<'a> ListService<'a> {
         Ok(())
     }
 
-    pub async fn nuke(&self, bot: Bot, msg: Message) -> Result<()> {
+    pub async fn nuke(&self, bot: Bot, msg: Message, delete_after_timeout: u64) -> Result<()> {
         if let Err(err) = bot.delete_message(msg.chat.id, msg.id).await {
             tracing::warn!(
                 error = %err,
@@ -173,7 +173,7 @@ impl<'a> ListService<'a> {
             bot.clone(),
             confirmation.chat.id,
             confirmation.id,
-            crate::utils::DELETE_AFTER_TIMEOUT,
+            delete_after_timeout,
         ));
         Ok(())
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,7 +7,7 @@ use teloxide::{
 };
 
 /// Default timeout in seconds for temporary messages.
-pub const DELETE_AFTER_TIMEOUT: u64 = 5;
+pub const DEFAULT_DELETE_AFTER_TIMEOUT: u64 = 5;
 
 /// Delete a message after the given delay in seconds.
 pub fn delete_after(

--- a/tests/archive_nuke.rs
+++ b/tests/archive_nuke.rs
@@ -84,7 +84,7 @@ async fn nuke_clears_data_and_sends_confirmation() {
     )
     .unwrap();
 
-    nuke_list(bot, msg, &db).await.unwrap();
+    nuke_list(bot, msg, &db, 5).await.unwrap();
 
     let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM items")
         .fetch_one(&*db)

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -87,3 +87,25 @@ fn config_from_env_custom_pool_size() {
     assert_eq!(cfg.db_pool_size, 2);
     assert!(cfg.ai.is_none());
 }
+
+#[test]
+#[serial]
+fn config_from_env_default_delete_after_timeout() {
+    std::env::remove_var("DELETE_AFTER_TIMEOUT");
+    std::env::set_var("DB_URL", "db");
+    std::env::remove_var("OPENAI_API_KEY");
+    let cfg = Config::from_env();
+    assert_eq!(cfg.delete_after_timeout, 5);
+    assert!(cfg.ai.is_none());
+}
+
+#[test]
+#[serial]
+fn config_from_env_custom_delete_after_timeout() {
+    std::env::set_var("DELETE_AFTER_TIMEOUT", "10");
+    std::env::set_var("DB_URL", "db");
+    std::env::remove_var("OPENAI_API_KEY");
+    let cfg = Config::from_env();
+    assert_eq!(cfg.delete_after_timeout, 10);
+    assert!(cfg.ai.is_none());
+}


### PR DESCRIPTION
## Summary
- support `DELETE_AFTER_TIMEOUT` in `Config`
- use configured timeout in delete handlers
- document new variable
- adjust tests for new parameter

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --no-fail-fast`


------
https://chatgpt.com/codex/tasks/task_e_684891a2b278832db43aac32eb2809af