### PR TITLE
Update env examples and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,38 +1,9 @@
-# Example environment configuration. Copy this file to `.env` and adjust the values.
-#
-# Values marked as optional may be omitted. Defaults are shown in comments.
+# Secrets for deployment. Copy this file to `.env`, fill in the values, and run
+# `fly secrets import < .env`.
 
 # Telegram bot token from @BotFather (required)
 TELOXIDE_TOKEN=
 
-# SQLite connection string (optional, defaults to "sqlite:shopping.db")
-# Use "sqlite:///data/shopping.db" when deploying on Fly.io
-DB_URL=sqlite:shopping.db
-
-# Maximum number of SQLite connections (optional, defaults to "5")
-DB_POOL_SIZE=5
-
-# Delay before temporary messages are deleted in seconds (optional, defaults to "5")
-DELETE_AFTER_TIMEOUT=5
-
-# Logging level such as "info" or "debug" (optional)
-RUST_LOG=info
-
 # OpenAI API key for voice and photo recognition (optional)
 OPENAI_API_KEY=
-
-# Speech-to-text model name (optional, defaults to "whisper-1")
-OPENAI_STT_MODEL=whisper-1
-
-# Chat model name (optional, defaults to "gpt-4.1")
-OPENAI_GPT_MODEL=gpt-4.1
-
-# Vision model name (optional, defaults to "gpt-4o")
-OPENAI_VISION_MODEL=gpt-4o
-
-# URL for the chat completion API (optional)
-OPENAI_CHAT_URL=
-
-# URL for the transcription API (optional)
-OPENAI_STT_URL=
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 2. Vision model configurable via `OPENAI_VISION_MODEL`.
 3. Custom OpenAI endpoints via `OPENAI_CHAT_URL` and `OPENAI_STT_URL`.
 4. Database pool size configurable via `DB_POOL_SIZE`.
-5. Example environment file `.env.example` documents all config variables.
+5. `.env.example` now lists only secrets. Non-secret configuration lives in `config.env.example`.
 6. Temporary message timeout configurable via `DELETE_AFTER_TIMEOUT`.
 
 ## [0.3.0] - 2025-06-09

--- a/README.md
+++ b/README.md
@@ -30,14 +30,22 @@ Send any message to the bot. Every non-empty line becomes an item. If you send a
 
 ## Configuration
 
-Set these environment variables before running:
+Copy `.env.example` to `.env` and fill in the secret values. Upload them on Fly.io with:
 
-- `TELOXIDE_TOKEN` – Telegram bot token from @BotFather
+```bash
+fly secrets import < .env
+```
+
+Non-secret settings can be customised via environment variables. `config.env.example` lists the available options.
+
+Set these variables as needed before running:
+
+- `TELOXIDE_TOKEN` – Telegram bot token from @BotFather (secret)
 - `DB_URL` – optional SQLite connection string (defaults to `sqlite:shopping.db`)
 - `DB_POOL_SIZE` – optional maximum number of SQLite connections (defaults to `5`)
 - `DELETE_AFTER_TIMEOUT` – optional delay in seconds before temporary messages are deleted (defaults to `5`)
 - `RUST_LOG` – optional logging level (e.g. `info` or `debug`)
-- `OPENAI_API_KEY` – optional API key for enabling voice and photo recognition
+- `OPENAI_API_KEY` – optional API key for enabling voice and photo recognition (secret)
 - `OPENAI_STT_MODEL` – optional model name (`whisper-1`, `gpt-4o-mini-transcribe`, or `gpt-4o-transcribe`)
 - `OPENAI_GPT_MODEL` – optional chat model name (defaults to `gpt-4.1`)
 - `OPENAI_VISION_MODEL` – optional vision model name (defaults to `gpt-4o`)

--- a/config.env.example
+++ b/config.env.example
@@ -1,0 +1,30 @@
+# Example non-secret configuration. Copy this file to another name to override defaults.
+# Values marked as optional may be omitted. Defaults are shown in comments.
+
+# SQLite connection string (optional, defaults to "sqlite:shopping.db")
+# Use "sqlite:///data/shopping.db" when deploying on Fly.io
+DB_URL=sqlite:shopping.db
+
+# Maximum number of SQLite connections (optional, defaults to "5")
+DB_POOL_SIZE=5
+
+# Delay before temporary messages are deleted in seconds (optional, defaults to "5")
+DELETE_AFTER_TIMEOUT=5
+
+# Logging level such as "info" or "debug" (optional)
+RUST_LOG=info
+
+# Speech-to-text model name (optional, defaults to "whisper-1")
+OPENAI_STT_MODEL=whisper-1
+
+# Chat model name (optional, defaults to "gpt-4.1")
+OPENAI_GPT_MODEL=gpt-4.1
+
+# Vision model name (optional, defaults to "gpt-4o")
+OPENAI_VISION_MODEL=gpt-4o
+
+# URL for the chat completion API (optional)
+OPENAI_CHAT_URL=
+
+# URL for the transcription API (optional)
+OPENAI_STT_URL=


### PR DESCRIPTION
## Summary
- keep `.env.example` for secrets only
- add `config.env.example` with non-secret configuration
- document secret import and new config file in README
- update changelog

## Testing
- `cargo fmt --all -- --check` *(fails: rustfmt missing)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: clippy missing)*
- `cargo nextest run --all` *(fails: no such command `nextest`)*

------
https://chatgpt.com/codex/tasks/task_e_68489c340d64832d8a60bb1cff46982a