### PR TITLE
Refactor shopping list wording

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -10,7 +10,7 @@ pub enum Command {
     Start,
     #[command(description = "display this text.")]
     Help,
-    #[command(description = "show the current shopping list.")]
+    #[command(description = "show the current list.")]
     List,
     #[command(description = "finalize and archive the current list, starting a new one.")]
     Archive,

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -4,10 +4,10 @@
 //! easy to update or translate.
 
 pub const HELP_TEXT: &str =
-    "Send me any text to add it to your shopping list. Each line will be a new item.\n\
+    "Send me any text to add it to your list. Each line will be a new item.\n\
              You can tap the checkbox button next to an item to mark it as bought.\n\n\
              <b>Commands:</b>\n\
-             /list - Show the current shopping list.\n\
+             /list - Show the current list.\n\
              /archive - Finalize and archive the current list, starting a new one.\n\
              /delete - Show a temporary panel to delete items from the list.\n\
              /share - Send the list as plain text for copying.\n\
@@ -20,9 +20,8 @@ pub const GPT_PARSING_DISABLED: &str = "GPT parsing is disabled.";
 pub const NO_ACTIVE_LIST_TO_EDIT: &str = "There is no active list to edit.";
 pub const NO_ACTIVE_LIST_TO_ARCHIVE: &str = "There is no active list to archive.";
 
-pub const LIST_EMPTY_ADD_ITEM: &str =
-    "Your shopping list is empty! Send any message to add an item.";
-pub const LIST_EMPTY: &str = "Your shopping list is empty!";
+pub const LIST_EMPTY_ADD_ITEM: &str = "Your list is empty! Send any message to add an item.";
+pub const LIST_EMPTY: &str = "Your list is empty!";
 pub const LIST_NOW_EMPTY: &str = "List is now empty!";
 pub const LIST_ARCHIVED: &str = "List archived! Send a message to start a new one.";
 pub const LIST_NUKED: &str = "The active list has been nuked.";


### PR DESCRIPTION
## Summary
- remove shopping terminology from user-facing strings
- update command description to show the list instead of the shopping list

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --all`


------
https://chatgpt.com/codex/tasks/task_e_6848aee13f04832d81bc5c135f443fd5