### PR TITLE
Improve logging for OpenAI calls

### DIFF
--- a/src/ai/gpt.rs
+++ b/src/ai/gpt.rs
@@ -100,6 +100,8 @@ pub async fn interpret_voice_command_inner(
     let resp = crate::ai::common::send_openai_request(api_key, builder).await?;
 
     let raw = resp.text().await?;
+    let snippet: String = raw.chars().take(200).collect();
+    debug!(snippet = %snippet, "chat response body");
     trace!(raw = %raw, "chat response");
     let chat: ChatResponse = serde_json::from_str(&raw)?;
     let content = chat

--- a/src/ai/stt.rs
+++ b/src/ai/stt.rs
@@ -39,7 +39,10 @@ async fn transcribe_audio_inner(
     let builder = client.post(url).multipart(form);
     let resp = crate::ai::common::send_openai_request(api_key, builder).await?;
 
-    let data: TranscriptionResponse = resp.json().await?;
+    let raw = resp.text().await?;
+    let snippet: String = raw.chars().take(200).collect();
+    debug!(snippet = %snippet, "transcription response body");
+    let data: TranscriptionResponse = serde_json::from_str(&raw)?;
     trace!(transcription = %data.text, "transcription successful");
     Ok(data.text)
 }


### PR DESCRIPTION
## Summary
- log request URLs and status codes when calling OpenAI APIs
- capture a short snippet of the response body for debugging

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --all`


------
https://chatgpt.com/codex/tasks/task_e_6848b20a6414832da9630e693bd7c56c