### PR TITLE
Refactor delete session helpers

### DIFF
--- a/src/handlers/delete.rs
+++ b/src/handlers/delete.rs
@@ -3,7 +3,10 @@ use anyhow::Result;
 use std::collections::HashSet;
 use teloxide::{
     prelude::*,
-    types::{ChatId, InlineKeyboardButton, InlineKeyboardMarkup, MessageId, UserId},
+    types::{
+        ChatId, InlineKeyboardButton, InlineKeyboardMarkup, MessageId, MaybeInaccessibleMessage,
+        User, UserId,
+    },
 };
 
 use crate::db::Item;
@@ -41,6 +44,160 @@ pub fn format_delete_list(
     )]);
 
     (text, InlineKeyboardMarkup::new(keyboard_buttons))
+}
+
+async fn cleanup_previous_session(bot: &Bot, db: &Database, user_id: UserId) -> Result<()> {
+    tracing::debug!(user_id = user_id.0, "Cleaning up previous delete session");
+    if let Some(prev) = db.get_delete_session(user_id.0 as i64).await? {
+        if let Some((chat_id, msg_id)) = prev.notice {
+            if let Err(err) = bot.delete_message(chat_id, msg_id).await {
+                tracing::warn!(
+                    error = %err,
+                    chat_id = chat_id.0,
+                    message_id = msg_id.0,
+                    "Failed to delete message",
+                );
+            }
+        }
+        if let Some(dm) = prev.dm_message_id {
+            if let Err(err) = bot.delete_message(ChatId(user_id.0 as i64), dm).await {
+                tracing::warn!(
+                    error = %err,
+                    chat_id = user_id.0,
+                    message_id = dm.0,
+                    "Failed to delete message",
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn start_delete_session(
+    bot: &Bot,
+    msg: &Message,
+    user: &User,
+    db: &Database,
+    items: &[Item],
+    delete_after_timeout: u64,
+) -> Result<()> {
+    tracing::debug!(
+        chat_id = msg.chat.id.0,
+        user_id = user.id.0,
+        "Starting delete session",
+    );
+
+    db.init_delete_session(user.id.0 as i64, msg.chat.id).await?;
+
+    let (base_text, keyboard) = format_delete_list(items, &HashSet::new());
+    let chat_name = msg
+        .chat
+        .title()
+        .map(ToString::to_string)
+        .unwrap_or_else(|| DEFAULT_CHAT_NAME.to_string());
+    let dm_text = delete_dm_text(&chat_name, &base_text);
+
+    match bot
+        .send_message(UserId(user.id.0), dm_text)
+        .reply_markup(keyboard)
+        .await
+    {
+        Ok(dm_msg) => {
+            db.set_delete_dm_message(user.id.0 as i64, dm_msg.id).await?;
+            if !msg.chat.is_private() {
+                let info = bot
+                    .send_message(msg.chat.id, delete_user_selecting_text(&user.first_name))
+                    .await?;
+                db.set_delete_notice(user.id.0 as i64, msg.chat.id, info.id).await?;
+            }
+        }
+        Err(err) => {
+            tracing::warn!("failed to send DM: {}", err);
+            let warn = bot.send_message(msg.chat.id, DELETE_DM_FAILED).await?;
+            drop(crate::delete_after(
+                bot.clone(),
+                warn.chat.id,
+                warn.id,
+                delete_after_timeout,
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+async fn process_done_callback(
+    bot: &Bot,
+    msg: &MaybeInaccessibleMessage,
+    user_id: i64,
+    db: &Database,
+) -> Result<()> {
+    if let Some(session) = db.get_delete_session(user_id).await? {
+        if session.dm_message_id.map(|m| m.0) != Some(msg.id().0) {
+            return Ok(());
+        }
+        for id in &session.selected {
+            db.delete_item(session.chat_id, *id).await?;
+        }
+        if let Some(main_list_id) = db.get_last_list_message_id(session.chat_id).await? {
+            update_list_message(bot, session.chat_id, MessageId(main_list_id), db).await?;
+        }
+        if let Some((chat_id, notice_id)) = session.notice {
+            if let Err(err) = bot.delete_message(chat_id, notice_id).await {
+                tracing::warn!(
+                    error = %err,
+                    chat_id = chat_id.0,
+                    message_id = notice_id.0,
+                    "Failed to delete message",
+                );
+            }
+        }
+        db.clear_delete_session(user_id).await?;
+    }
+    if let Err(err) = bot.delete_message(msg.chat().id, msg.id()).await {
+        tracing::warn!(
+            error = %err,
+            chat_id = msg.chat().id.0,
+            message_id = msg.id().0,
+            "Failed to delete message",
+        );
+    }
+    Ok(())
+}
+
+async fn toggle_selection(
+    bot: &Bot,
+    msg: &MaybeInaccessibleMessage,
+    user_id: i64,
+    id: i64,
+    db: &Database,
+) -> Result<()> {
+    if let Some(mut session) = db.get_delete_session(user_id).await? {
+        if session.dm_message_id.map(|m| m.0) != Some(msg.id().0) {
+            return Ok(());
+        }
+        if session.selected.contains(&id) {
+            session.selected.remove(&id);
+        } else {
+            session.selected.insert(id);
+        }
+        db.update_delete_selection(user_id, &session.selected).await?;
+        let items = db.list_items(session.chat_id).await?;
+        let (text, keyboard) = format_delete_list(&items, &session.selected);
+        if let Err(err) = bot
+            .edit_message_text(msg.chat().id, msg.id(), text)
+            .reply_markup(keyboard)
+            .await
+        {
+            tracing::warn!(
+                error = %err,
+                chat_id = msg.chat().id.0,
+                message_id = msg.id().0,
+                "Failed to edit message",
+            );
+        }
+    }
+    Ok(())
 }
 
 pub async fn enter_delete_mode(
@@ -81,75 +238,14 @@ pub async fn enter_delete_mode(
         None => return Ok(()),
     };
 
-    if let Some(prev) = db.get_delete_session(user.id.0 as i64).await? {
-        if let Some((c, m)) = prev.notice {
-            if let Err(err) = bot.delete_message(c, m).await {
-                tracing::warn!(
-                    error = %err,
-                    chat_id = c.0,
-                    message_id = m.0,
-                    "Failed to delete message",
-                );
-            }
-        }
-        if let Some(dm) = prev.dm_message_id {
-            if let Err(err) = bot.delete_message(ChatId(user.id.0 as i64), dm).await {
-                tracing::warn!(
-                    error = %err,
-                    chat_id = user.id.0,
-                    message_id = dm.0,
-                    "Failed to delete message",
-                );
-            }
-        }
-    }
+    cleanup_previous_session(&bot, db, user.id).await?;
 
     let items = db.list_items(msg.chat.id).await?;
     if items.is_empty() {
         return Ok(());
     }
 
-    db.init_delete_session(user.id.0 as i64, msg.chat.id)
-        .await?;
-
-    let (base_text, keyboard) = { format_delete_list(&items, &HashSet::new()) };
-
-    let chat_name = msg
-        .chat
-        .title()
-        .map(ToString::to_string)
-        .unwrap_or_else(|| DEFAULT_CHAT_NAME.to_string());
-    let dm_text = delete_dm_text(&chat_name, &base_text);
-
-    match bot
-        .send_message(UserId(user.id.0), dm_text.clone())
-        .reply_markup(keyboard)
-        .await
-    {
-        Ok(dm_msg) => {
-            db.set_delete_dm_message(user.id.0 as i64, dm_msg.id)
-                .await?;
-            if !msg.chat.is_private() {
-                let info = bot
-                    .send_message(msg.chat.id, delete_user_selecting_text(&user.first_name))
-                    .await?;
-                db.set_delete_notice(user.id.0 as i64, msg.chat.id, info.id)
-                    .await?;
-            }
-        }
-        Err(err) => {
-            tracing::warn!("failed to send DM: {}", err);
-            let warn = bot.send_message(msg.chat.id, DELETE_DM_FAILED).await?;
-            drop(crate::delete_after(
-                bot.clone(),
-                warn.chat.id,
-                warn.id,
-                delete_after_timeout,
-            ));
-        }
-    }
-
-    Ok(())
+    start_delete_session(&bot, &msg, user, db, &items, delete_after_timeout).await
 }
 
 pub async fn callback_handler(bot: Bot, q: CallbackQuery, db: Database) -> Result<()> {
@@ -158,69 +254,9 @@ pub async fn callback_handler(bot: Bot, q: CallbackQuery, db: Database) -> Resul
             let user_id = q.from.id.0 as i64;
 
             if id_str == "done" {
-                if let Some(session) = db.get_delete_session(user_id).await? {
-                    if session.dm_message_id.map(|m| m.0) != Some(msg.id().0) {
-                        return Ok(());
-                    }
-                    for id in &session.selected {
-                        db.delete_item(session.chat_id, *id).await?;
-                    }
-
-                    if let Some(main_list_id) = db.get_last_list_message_id(session.chat_id).await?
-                    {
-                        update_list_message(&bot, session.chat_id, MessageId(main_list_id), &db)
-                            .await?;
-                    }
-
-                    if let Some((chat_id, notice_id)) = session.notice {
-                        if let Err(err) = bot.delete_message(chat_id, notice_id).await {
-                            tracing::warn!(
-                                error = %err,
-                                chat_id = chat_id.0,
-                                message_id = notice_id.0,
-                                "Failed to delete message",
-                            );
-                        }
-                    }
-
-                    db.clear_delete_session(user_id).await?;
-                }
-
-                if let Err(err) = bot.delete_message(msg.chat().id, msg.id()).await {
-                    tracing::warn!(
-                        error = %err,
-                        chat_id = msg.chat().id.0,
-                        message_id = msg.id().0,
-                        "Failed to delete message",
-                    );
-                }
+                process_done_callback(&bot, &msg, user_id, &db).await?;
             } else if let Ok(id) = id_str.parse::<i64>() {
-                if let Some(mut session) = db.get_delete_session(user_id).await? {
-                    if session.dm_message_id.map(|m| m.0) != Some(msg.id().0) {
-                        return Ok(());
-                    }
-                    if session.selected.contains(&id) {
-                        session.selected.remove(&id);
-                    } else {
-                        session.selected.insert(id);
-                    }
-                    db.update_delete_selection(user_id, &session.selected)
-                        .await?;
-                    let items = db.list_items(session.chat_id).await?;
-                    let (text, keyboard) = format_delete_list(&items, &session.selected);
-                    if let Err(err) = bot
-                        .edit_message_text(msg.chat().id, msg.id(), text)
-                        .reply_markup(keyboard)
-                        .await
-                    {
-                        tracing::warn!(
-                            error = %err,
-                            chat_id = msg.chat().id.0,
-                            message_id = msg.id().0,
-                            "Failed to edit message",
-                        );
-                    }
-                }
+                toggle_selection(&bot, &msg, user_id, id, &db).await?;
             }
         } else if let Ok(id) = data.parse::<i64>() {
             db.toggle_item(msg.chat().id, id).await?;
@@ -230,4 +266,61 @@ pub async fn callback_handler(bot: Bot, q: CallbackQuery, db: Database) -> Resul
 
     bot.answer_callback_query(q.id).await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::util::init_test_db;
+    use teloxide::types::{ChatId, MaybeInaccessibleMessage, MessageId, UserId};
+    use wiremock::{matchers::{method, path}, Mock, MockServer, ResponseTemplate};
+
+    #[tokio::test]
+    async fn cleanup_previous_session_deletes_messages() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/botTEST/DeleteMessage"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(r#"{"ok":true,"result":true}"#, "application/json"))
+            .expect(2)
+            .mount(&server)
+            .await;
+
+        let bot = Bot::new("TEST").set_api_url(reqwest::Url::parse(&server.uri()).unwrap());
+        let db = init_test_db().await;
+        let user = UserId(1);
+        db.init_delete_session(user.0 as i64, ChatId(1)).await.unwrap();
+        db.set_delete_notice(user.0 as i64, ChatId(1), MessageId(10)).await.unwrap();
+        db.set_delete_dm_message(user.0 as i64, MessageId(11)).await.unwrap();
+
+        cleanup_previous_session(&bot, &db, user).await.unwrap();
+        server.verify().await;
+    }
+
+    #[tokio::test]
+    async fn toggle_selection_updates_db() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/botTEST/EditMessageText"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(r#"{"ok":true,"result":true}"#, "application/json"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let bot = Bot::new("TEST").set_api_url(reqwest::Url::parse(&server.uri()).unwrap());
+        let db = init_test_db().await;
+        let chat = ChatId(1);
+        db.add_item(chat, "Milk").await.unwrap();
+        let items = db.list_items(chat).await.unwrap();
+        let item_id = items[0].id;
+
+        db.init_delete_session(1, chat).await.unwrap();
+        db.set_delete_dm_message(1, MessageId(5)).await.unwrap();
+        let msg_json = r#"{"message_id":5,"date":0,"chat":{"id":1,"type":"private"}}"#;
+        let msg: MaybeInaccessibleMessage = serde_json::from_str(msg_json).unwrap();
+
+        toggle_selection(&bot, &msg, 1, item_id, &db).await.unwrap();
+        let session = db.get_delete_session(1).await.unwrap().unwrap();
+        assert!(session.selected.contains(&item_id));
+        server.verify().await;
+    }
 }


### PR DESCRIPTION
## Summary
- refactor delete session logic into helper functions
- delegate entry and callback handlers to new helpers
- test delete session helpers

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --all`

------
https://chatgpt.com/codex/tasks/task_e_68491d59639c832d8efc75782c75e121