### PR TITLE
Add central AI prompt constants

### DIFF
--- a/src/ai.rs
+++ b/src/ai.rs
@@ -1,5 +1,6 @@
 pub mod common;
 pub mod config;
 pub mod gpt;
+pub mod prompts;
 pub mod stt;
 pub mod vision;

--- a/src/ai/gpt.rs
+++ b/src/ai/gpt.rs
@@ -1,4 +1,5 @@
 use crate::ai::common::{request_items, OPENAI_CHAT_URL};
+use crate::ai::prompts::TEXT_PARSING_PROMPT;
 use anyhow::Result;
 use tracing::instrument;
 
@@ -25,8 +26,7 @@ pub async fn parse_items_gpt_inner(
     text: &str,
     url: &str,
 ) -> Result<Vec<String>> {
-    let prompt = "Extract the items from the user's text. Use the nominative form for nouns when it does not change the meaning. Convert number words to digits so 'три ананаса' becomes '3 ананаса'. Respond with a JSON object like {\"items\": [\"1 milk\"]}";
-    let body = crate::ai::common::build_text_chat_body(model, prompt, text);
+    let body = crate::ai::common::build_text_chat_body(model, TEXT_PARSING_PROMPT, text);
 
     request_items(api_key, &body, url).await
 }

--- a/src/ai/prompts.rs
+++ b/src/ai/prompts.rs
@@ -1,0 +1,17 @@
+//! Common system prompts used by the AI helpers.
+//!
+//! Centralizing these strings makes it easy to tweak how text, photos
+//! and audio are interpreted without digging through multiple modules.
+
+/// System prompt for parsing items from free-form text.
+pub const TEXT_PARSING_PROMPT: &str = "Extract the items from the user's text. Use the nominative form for nouns when it does not change the meaning. Convert number words to digits so 'три ананаса' becomes '3 ананаса'. Respond with a JSON object like {\"items\": [\"1 milk\"]}";
+
+/// System prompt for parsing items from a photo.
+pub const PHOTO_PARSING_PROMPT: &str = "Extract the items shown in the photo. Respond with a JSON object like {\"items\": [\"apples\"]}.";
+
+/// Default instructions passed to GPT-based transcription models.
+/// The prompt also asks the model to keep verbs intact so commands like
+/// "delete" are not dropped during transcription. Quantities should be
+/// written using digits when possible. Convert spelled-out numbers to digits
+/// so phrases like "три ананаса" become "3 ананаса".
+pub const DEFAULT_STT_PROMPT: &str = "Transcribe the user's request about the list. Keep verbs like 'add' or 'delete' exactly as spoken. Use digits for quantities and convert number words to digits.";

--- a/src/ai/stt.rs
+++ b/src/ai/stt.rs
@@ -3,12 +3,7 @@ use reqwest::multipart::{Form, Part};
 use serde::Deserialize;
 use tracing::{debug, instrument, trace};
 
-/// Default instructions passed to GPT-based transcription models.
-/// The prompt also asks the model to keep verbs intact so commands like
-/// "delete" are not dropped during transcription. Quantities should be
-/// written using digits when possible. Convert spelled-out numbers to digits
-/// so phrases like "три ананаса" become "3 ананаса".
-pub const DEFAULT_PROMPT: &str = "Transcribe the user's request about the list. Keep verbs like 'add' or 'delete' exactly as spoken. Use digits for quantities and convert number words to digits.";
+pub use crate::ai::prompts::DEFAULT_STT_PROMPT as DEFAULT_PROMPT;
 
 #[derive(Deserialize)]
 struct TranscriptionResponse {

--- a/src/ai/vision.rs
+++ b/src/ai/vision.rs
@@ -1,4 +1,5 @@
 use crate::ai::common::{request_items, OPENAI_CHAT_URL};
+use crate::ai::prompts::PHOTO_PARSING_PROMPT;
 use anyhow::Result;
 use base64::Engine as _;
 use tracing::instrument;
@@ -24,8 +25,7 @@ pub async fn parse_photo_items_inner(
 ) -> Result<Vec<String>> {
     let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
     let data_url = format!("data:image/png;base64,{}", encoded);
-    let prompt = "Extract the items shown in the photo. Respond with a JSON object like {\"items\": [\"apples\"]}.";
-    let body = crate::ai::common::build_image_chat_body(model, prompt, &data_url);
+    let body = crate::ai::common::build_image_chat_body(model, PHOTO_PARSING_PROMPT, &data_url);
 
     request_items(api_key, &body, url).await
 }


### PR DESCRIPTION
## Summary
- define standard prompts in `src/ai/prompts.rs`
- reference these constants in GPT, vision, and STT helpers

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --all`


------
https://chatgpt.com/codex/tasks/task_e_684a83cb8a6c832d873e6df59b2dc4be