### PR TITLE
Introduce ChatKey and ItemId wrappers

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -7,10 +7,12 @@ pub mod chat_state;
 pub mod database;
 pub mod delete_session;
 pub mod items;
+pub mod types;
 
 pub use database::Database;
 
 pub use items::Item;
+pub use types::{ChatKey, ItemId};
 
 pub fn prepare_sqlite_url(url: &str) -> String {
     if url.starts_with("sqlite:") && !url.contains("mode=") && !url.contains(":memory:") {

--- a/src/db/chat_state.rs
+++ b/src/db/chat_state.rs
@@ -1,6 +1,7 @@
 use super::Database;
+use crate::db::types::ChatKey;
 use anyhow::Result;
-use teloxide::types::{ChatId, MessageId};
+use teloxide::types::MessageId;
 
 #[derive(sqlx::FromRow)]
 struct ChatState {
@@ -8,12 +9,12 @@ struct ChatState {
 }
 
 impl Database {
-    pub async fn get_last_list_message_id(&self, chat_id: ChatId) -> Result<Option<i32>> {
+    pub async fn get_last_list_message_id(&self, chat_id: ChatKey) -> Result<Option<i32>> {
         tracing::trace!(chat_id = chat_id.0, "Fetching last list message id");
         let result = sqlx::query_as::<_, ChatState>(
             "SELECT last_list_message_id FROM chat_state WHERE chat_id = ?",
         )
-        .bind(chat_id.0)
+        .bind::<i64>(chat_id.into())
         .fetch_optional(self.pool())
         .await?;
         Ok(result.map(|r| r.last_list_message_id))
@@ -21,7 +22,7 @@ impl Database {
 
     pub async fn update_last_list_message_id(
         &self,
-        chat_id: ChatId,
+        chat_id: ChatKey,
         message_id: MessageId,
     ) -> Result<()> {
         tracing::debug!(
@@ -33,17 +34,17 @@ impl Database {
             "INSERT INTO chat_state (chat_id, last_list_message_id) VALUES (?, ?) \
              ON CONFLICT(chat_id) DO UPDATE SET last_list_message_id = excluded.last_list_message_id",
         )
-        .bind(chat_id.0)
+        .bind::<i64>(chat_id.into())
         .bind(message_id.0)
         .execute(self.pool())
         .await?;
         Ok(())
     }
 
-    pub async fn clear_last_list_message_id(&self, chat_id: ChatId) -> Result<()> {
+    pub async fn clear_last_list_message_id(&self, chat_id: ChatKey) -> Result<()> {
         tracing::debug!(chat_id = chat_id.0, "Clearing last list message id");
         sqlx::query("DELETE FROM chat_state WHERE chat_id = ?")
-            .bind(chat_id.0)
+            .bind::<i64>(chat_id.into())
             .execute(self.pool())
             .await?;
         Ok(())

--- a/src/db/delete_session.rs
+++ b/src/db/delete_session.rs
@@ -1,4 +1,5 @@
 use super::Database;
+use crate::db::types::{ChatKey, ItemId};
 use anyhow::Result;
 use std::collections::HashSet;
 use teloxide::types::{ChatId, MessageId};
@@ -13,18 +14,20 @@ struct DeleteSessionRow {
 }
 
 pub struct DeleteSession {
-    pub chat_id: ChatId,
-    pub selected: HashSet<i64>,
+    pub chat_id: ChatKey,
+    pub selected: HashSet<ItemId>,
     pub notice: Option<(ChatId, MessageId)>,
     pub dm_message_id: Option<MessageId>,
 }
 
-fn parse_selected(s: &str) -> HashSet<i64> {
-    s.split(',').filter_map(|p| p.parse::<i64>().ok()).collect()
+fn parse_selected(s: &str) -> HashSet<ItemId> {
+    s.split(',')
+        .filter_map(|p| p.parse::<i64>().ok().map(ItemId))
+        .collect()
 }
 
-fn join_selected(set: &HashSet<i64>) -> String {
-    let mut ids: Vec<i64> = set.iter().copied().collect();
+fn join_selected(set: &HashSet<ItemId>) -> String {
+    let mut ids: Vec<i64> = set.iter().copied().map(Into::into).collect();
     ids.sort_unstable();
     ids.into_iter()
         .map(|id| id.to_string())
@@ -33,14 +36,14 @@ fn join_selected(set: &HashSet<i64>) -> String {
 }
 
 impl Database {
-    pub async fn init_delete_session(&self, user_id: i64, chat_id: ChatId) -> Result<()> {
+    pub async fn init_delete_session(&self, user_id: i64, chat_id: ChatKey) -> Result<()> {
         tracing::debug!(user_id, chat_id = chat_id.0, "Initializing delete session");
         sqlx::query(
             "INSERT INTO delete_session (user_id, chat_id, selected) VALUES (?, ?, '') \
              ON CONFLICT(user_id) DO UPDATE SET chat_id=excluded.chat_id, selected='', notice_chat_id=NULL, notice_message_id=NULL, dm_message_id=NULL",
         )
         .bind(user_id)
-        .bind(chat_id.0)
+        .bind::<i64>(chat_id.into())
         .execute(self.pool())
         .await?;
         Ok(())
@@ -49,10 +52,10 @@ impl Database {
     pub async fn update_delete_selection(
         &self,
         user_id: i64,
-        selected: &HashSet<i64>,
+        selected: &HashSet<ItemId>,
     ) -> Result<()> {
-        tracing::trace!(user_id, selection=?selected, "Updating delete selection");
         let joined = join_selected(selected);
+        tracing::trace!(user_id, selection=?joined, "Updating delete selection");
         sqlx::query("UPDATE delete_session SET selected = ? WHERE user_id = ?")
             .bind(joined)
             .bind(user_id)
@@ -64,7 +67,7 @@ impl Database {
     pub async fn set_delete_notice(
         &self,
         user_id: i64,
-        chat_id: ChatId,
+        chat_id: ChatKey,
         message_id: MessageId,
     ) -> Result<()> {
         tracing::debug!(
@@ -76,7 +79,7 @@ impl Database {
         sqlx::query(
             "UPDATE delete_session SET notice_chat_id = ?, notice_message_id = ? WHERE user_id = ?",
         )
-        .bind(chat_id.0)
+        .bind::<i64>(chat_id.into())
         .bind(message_id.0)
         .bind(user_id)
         .execute(self.pool())
@@ -112,7 +115,7 @@ impl Database {
                 _ => None,
             };
             Ok(Some(DeleteSession {
-                chat_id: ChatId(row.chat_id),
+                chat_id: ChatKey(row.chat_id),
                 selected: parse_selected(&row.selected),
                 notice,
                 dm_message_id: row.dm_message_id.map(MessageId),
@@ -135,6 +138,7 @@ impl Database {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::db::types::{ChatKey, ItemId};
     use crate::tests::util::init_test_db;
     use proptest::prelude::*;
     use teloxide::types::{ChatId, MessageId};
@@ -148,18 +152,18 @@ mod tests {
     #[test]
     fn join_selected_sorts() {
         let mut set = HashSet::new();
-        set.insert(5);
-        set.insert(3);
-        set.insert(7);
+        set.insert(ItemId(5));
+        set.insert(ItemId(3));
+        set.insert(ItemId(7));
         assert_eq!(join_selected(&set), "3,5,7");
     }
 
     #[test]
     fn parse_join_roundtrip() {
         let mut original = HashSet::new();
-        original.insert(2);
-        original.insert(1);
-        original.insert(9);
+        original.insert(ItemId(2));
+        original.insert(ItemId(1));
+        original.insert(ItemId(9));
         let joined = join_selected(&original);
         let parsed = parse_selected(&joined);
         assert_eq!(original, parsed);
@@ -168,6 +172,7 @@ mod tests {
     proptest! {
         #[test]
         fn prop_parse_join_roundtrip(set in proptest::collection::hash_set(0i64..1000, 0..20)) {
+            let set: HashSet<ItemId> = set.into_iter().map(ItemId).collect();
             let joined = join_selected(&set);
             let parsed = parse_selected(&joined);
             prop_assert_eq!(set, parsed);
@@ -175,13 +180,14 @@ mod tests {
 
         #[test]
         fn prop_join_selected_sorted(set in proptest::collection::hash_set(-1000i64..1000, 0..20)) {
+            let set: HashSet<ItemId> = set.into_iter().map(ItemId).collect();
             let joined = join_selected(&set);
             let parsed: Vec<i64> = if joined.is_empty() {
                 Vec::new()
             } else {
                 joined.split(',').map(|s| s.parse().unwrap()).collect()
             };
-            let mut expected: Vec<i64> = set.iter().copied().collect();
+            let mut expected: Vec<i64> = set.iter().map(|i| i.0).collect();
             expected.sort_unstable();
             prop_assert_eq!(parsed, expected);
         }
@@ -192,23 +198,24 @@ mod tests {
         let db = init_test_db().await;
         let user = 1i64;
         let chat_a = ChatId(10);
-        db.init_delete_session(user, chat_a).await?;
+        db.init_delete_session(user, ChatKey(chat_a.0)).await?;
 
         let mut session = db.get_delete_session(user).await?.unwrap();
-        assert_eq!(session.chat_id, chat_a);
+        assert_eq!(ChatId::from(session.chat_id), chat_a);
         assert!(session.selected.is_empty());
         assert!(session.notice.is_none());
         assert!(session.dm_message_id.is_none());
 
         let mut selected = HashSet::new();
-        selected.insert(5);
-        selected.insert(7);
+        selected.insert(ItemId(5));
+        selected.insert(ItemId(7));
         db.update_delete_selection(user, &selected).await?;
 
         session = db.get_delete_session(user).await?.unwrap();
         assert_eq!(session.selected, selected);
 
-        db.set_delete_notice(user, ChatId(20), MessageId(3)).await?;
+        db.set_delete_notice(user, ChatKey(20), MessageId(3))
+            .await?;
         db.set_delete_dm_message(user, MessageId(4)).await?;
 
         session = db.get_delete_session(user).await?.unwrap();

--- a/src/db/items.rs
+++ b/src/db/items.rs
@@ -1,76 +1,95 @@
 use super::Database;
+use crate::db::types::{ChatKey, ItemId};
 use anyhow::Result;
-use teloxide::types::ChatId;
 
-#[derive(sqlx::FromRow, Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Item {
-    pub id: i64,
+    pub id: ItemId,
     pub text: String,
     pub done: bool,
 }
 
+#[derive(sqlx::FromRow)]
+struct ItemRow {
+    id: i64,
+    text: String,
+    done: bool,
+}
+
 impl Database {
-    pub async fn add_item(&self, chat_id: ChatId, text: &str) -> Result<()> {
+    pub async fn add_item(&self, chat_id: ChatKey, text: &str) -> Result<()> {
         tracing::trace!(chat_id = chat_id.0, text = %text, "Adding item");
         sqlx::query("INSERT INTO items (chat_id, text) VALUES (?, ?)")
-            .bind(chat_id.0)
+            .bind::<i64>(chat_id.into())
             .bind(text)
             .execute(self.pool())
             .await?;
         Ok(())
     }
 
-    pub async fn list_items(&self, chat_id: ChatId) -> Result<Vec<Item>> {
+    pub async fn list_items(&self, chat_id: ChatKey) -> Result<Vec<Item>> {
         tracing::trace!(chat_id = chat_id.0, "Listing items");
-        sqlx::query_as("SELECT id, text, done FROM items WHERE chat_id = ? ORDER BY id")
-            .bind(chat_id.0)
-            .fetch_all(self.pool())
-            .await
-            .map_err(Into::into)
+        let rows: Vec<ItemRow> =
+            sqlx::query_as("SELECT id, text, done FROM items WHERE chat_id = ? ORDER BY id")
+                .bind::<i64>(chat_id.into())
+                .fetch_all(self.pool())
+                .await?;
+        Ok(rows
+            .into_iter()
+            .map(|r| Item {
+                id: ItemId(r.id),
+                text: r.text,
+                done: r.done,
+            })
+            .collect())
     }
 
-    pub async fn toggle_item(&self, chat_id: ChatId, id: i64) -> Result<()> {
-        tracing::trace!(chat_id = chat_id.0, item_id = id, "Toggling item");
+    pub async fn toggle_item(&self, chat_id: ChatKey, id: ItemId) -> Result<()> {
+        let id_val: i64 = id.into();
+        tracing::trace!(chat_id = chat_id.0, item_id = id_val, "Toggling item");
         sqlx::query("UPDATE items SET done = NOT done WHERE id = ? AND chat_id = ?")
-            .bind(id)
-            .bind(chat_id.0)
+            .bind(id_val)
+            .bind::<i64>(chat_id.into())
             .execute(self.pool())
             .await?;
         Ok(())
     }
 
-    pub async fn delete_item(&self, chat_id: ChatId, id: i64) -> Result<()> {
-        tracing::trace!(chat_id = chat_id.0, item_id = id, "Deleting item");
+    pub async fn delete_item(&self, chat_id: ChatKey, id: ItemId) -> Result<()> {
+        let id_val: i64 = id.into();
+        tracing::trace!(chat_id = chat_id.0, item_id = id_val, "Deleting item");
         sqlx::query("DELETE FROM items WHERE id = ? AND chat_id = ?")
-            .bind(id)
-            .bind(chat_id.0)
+            .bind(id_val)
+            .bind::<i64>(chat_id.into())
             .execute(self.pool())
             .await?;
         Ok(())
     }
 
-    pub async fn delete_all_items(&self, chat_id: ChatId) -> Result<()> {
+    pub async fn delete_all_items(&self, chat_id: ChatKey) -> Result<()> {
         tracing::debug!(chat_id = chat_id.0, "Deleting all items");
         sqlx::query("DELETE FROM items WHERE chat_id = ?")
-            .bind(chat_id.0)
+            .bind::<i64>(chat_id.into())
             .execute(self.pool())
             .await?;
         Ok(())
     }
 
-    pub async fn delete_items(&self, chat_id: ChatId, ids: &[i64]) -> Result<()> {
-        tracing::trace!(chat_id = chat_id.0, ?ids, "Deleting multiple items");
+    pub async fn delete_items(&self, chat_id: ChatKey, ids: &[ItemId]) -> Result<()> {
         if ids.is_empty() {
             return Ok(());
         }
 
+        let id_values: Vec<i64> = ids.iter().copied().map(Into::into).collect();
+        tracing::trace!(chat_id = chat_id.0, ?id_values, "Deleting multiple items");
+
         let mut builder =
             sqlx::QueryBuilder::<sqlx::Sqlite>::new("DELETE FROM items WHERE chat_id = ");
-        builder.push_bind(chat_id.0);
+        builder.push_bind::<i64>(chat_id.into());
         builder.push(" AND id IN (");
         {
             let mut separated = builder.separated(", ");
-            for id in ids {
+            for id in &id_values {
                 separated.push_bind(id);
             }
         }

--- a/src/db/types.rs
+++ b/src/db/types.rs
@@ -1,8 +1,10 @@
 pub use teloxide::types::ChatId;
 
+/// Identifier for a chat.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ChatKey(pub i64);
 
+/// Identifier for an item.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ItemId(pub i64);
 

--- a/src/db/types.rs
+++ b/src/db/types.rs
@@ -1,0 +1,49 @@
+pub use teloxide::types::ChatId;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ChatKey(pub i64);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ItemId(pub i64);
+
+impl std::fmt::Display for ItemId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<ChatId> for ChatKey {
+    fn from(id: ChatId) -> Self {
+        ChatKey(id.0)
+    }
+}
+
+impl From<ChatKey> for ChatId {
+    fn from(key: ChatKey) -> Self {
+        ChatId(key.0)
+    }
+}
+
+impl From<i64> for ChatKey {
+    fn from(id: i64) -> Self {
+        ChatKey(id)
+    }
+}
+
+impl From<ChatKey> for i64 {
+    fn from(key: ChatKey) -> Self {
+        key.0
+    }
+}
+
+impl From<i64> for ItemId {
+    fn from(id: i64) -> Self {
+        ItemId(id)
+    }
+}
+
+impl From<ItemId> for i64 {
+    fn from(id: ItemId) -> Self {
+        id.0
+    }
+}

--- a/src/handlers/list.rs
+++ b/src/handlers/list.rs
@@ -1,4 +1,4 @@
-use crate::db::{Database, Item};
+use crate::db::{ChatKey, Database, Item};
 use anyhow::Result;
 use teloxide::{
     prelude::*,
@@ -92,7 +92,7 @@ where
 {
     let mut added = 0usize;
     for item in items {
-        db.add_item(chat_id, &item).await?;
+        db.add_item(ChatKey(chat_id.0), &item).await?;
         added += 1;
     }
 

--- a/src/handlers/voice.rs
+++ b/src/handlers/voice.rs
@@ -1,7 +1,6 @@
-
+use crate::db::Item;
 use crate::db::{ChatKey, Database, ItemId};
 use crate::utils::download_file;
-use anyhow::Result;
 use teloxide::prelude::*;
 
 use crate::ai::config::AiConfig;

--- a/src/handlers/voice.rs
+++ b/src/handlers/voice.rs
@@ -1,7 +1,19 @@
 use crate::db::Item;
 use crate::db::{ChatKey, Database, ItemId};
 use crate::utils::download_file;
-use teloxide::prelude::*;
+            let text = found.text;
+            tracing::debug!(
+                chat_id = chat_id.0,
+                item_id = found.id.0,
+                %text,
+                "Matched voice item for deletion"
+            );
+            deleted.push(text);
+    tracing::debug!(
+        chat_id = chat_id.0,
+        count = ids.len(),
+        "Deleted matched items"
+    );
 
 use crate::ai::config::AiConfig;
 use crate::ai::gpt::{interpret_voice_command, VoiceCommand};

--- a/tests/archive_nuke.rs
+++ b/tests/archive_nuke.rs
@@ -1,3 +1,4 @@
+use shopbot::db::ChatKey;
 use shopbot::tests::util::init_test_db;
 use shopbot::{archive, nuke_list, LIST_ARCHIVED, LIST_NUKED};
 use teloxide::{
@@ -32,8 +33,9 @@ async fn archive_clears_data_and_sends_confirmation() {
     let bot = Bot::new("TEST").set_api_url(reqwest::Url::parse(&server.uri()).unwrap());
     let db = init_test_db().await;
     let chat = ChatId(1);
-    db.add_item(chat, "Milk").await.unwrap();
-    db.update_last_list_message_id(chat, MessageId(10))
+    let key = ChatKey(chat.0);
+    db.add_item(key, "Milk").await.unwrap();
+    db.update_last_list_message_id(key, MessageId(10))
         .await
         .unwrap();
 
@@ -44,7 +46,7 @@ async fn archive_clears_data_and_sends_confirmation() {
         .await
         .unwrap();
     assert_eq!(count.0, 0);
-    assert!(db.get_last_list_message_id(chat).await.unwrap().is_none());
+    assert!(db.get_last_list_message_id(key).await.unwrap().is_none());
 
     server.verify().await;
 }
@@ -74,8 +76,9 @@ async fn nuke_clears_data_and_sends_confirmation() {
     let bot = Bot::new("TEST").set_api_url(reqwest::Url::parse(&server.uri()).unwrap());
     let db = init_test_db().await;
     let chat = ChatId(1);
-    db.add_item(chat, "Milk").await.unwrap();
-    db.update_last_list_message_id(chat, MessageId(5))
+    let key = ChatKey(chat.0);
+    db.add_item(key, "Milk").await.unwrap();
+    db.update_last_list_message_id(key, MessageId(5))
         .await
         .unwrap();
 
@@ -91,7 +94,7 @@ async fn nuke_clears_data_and_sends_confirmation() {
         .await
         .unwrap();
     assert_eq!(count.0, 0);
-    assert!(db.get_last_list_message_id(chat).await.unwrap().is_none());
+    assert!(db.get_last_list_message_id(key).await.unwrap().is_none());
 
     server.verify().await;
 }

--- a/tests/cross_chat.rs
+++ b/tests/cross_chat.rs
@@ -1,3 +1,4 @@
+use shopbot::db::{ChatKey, ItemId};
 use shopbot::tests::util::init_test_db;
 use teloxide::types::ChatId;
 
@@ -6,12 +7,12 @@ async fn toggle_different_chat_has_no_effect() {
     let db = init_test_db().await;
     let chat1 = ChatId(1);
     let chat2 = ChatId(2);
-    db.add_item(chat1, "Milk").await.unwrap();
+    db.add_item(ChatKey(chat1.0), "Milk").await.unwrap();
 
-    let item = db.list_items(chat1).await.unwrap()[0].clone();
-    db.toggle_item(chat2, item.id).await.unwrap();
+    let item = db.list_items(ChatKey(chat1.0)).await.unwrap()[0].clone();
+    db.toggle_item(ChatKey(chat2.0), item.id).await.unwrap();
 
-    let after = db.list_items(chat1).await.unwrap()[0].clone();
+    let after = db.list_items(ChatKey(chat1.0)).await.unwrap()[0].clone();
     assert!(!after.done);
 }
 
@@ -20,11 +21,11 @@ async fn delete_different_chat_has_no_effect() {
     let db = init_test_db().await;
     let chat1 = ChatId(1);
     let chat2 = ChatId(2);
-    db.add_item(chat1, "Milk").await.unwrap();
-    let item = db.list_items(chat1).await.unwrap()[0].clone();
+    db.add_item(ChatKey(chat1.0), "Milk").await.unwrap();
+    let item = db.list_items(ChatKey(chat1.0)).await.unwrap()[0].clone();
 
-    db.delete_item(chat2, item.id).await.unwrap();
-    let remaining = db.list_items(chat1).await.unwrap();
+    db.delete_item(ChatKey(chat2.0), item.id).await.unwrap();
+    let remaining = db.list_items(ChatKey(chat1.0)).await.unwrap();
     assert_eq!(remaining.len(), 1);
 }
 
@@ -34,12 +35,12 @@ async fn delete_multiple_different_chat_has_no_effect() {
     let chat1 = ChatId(1);
     let chat2 = ChatId(2);
     for _ in 0..3 {
-        db.add_item(chat1, "Item").await.unwrap();
+        db.add_item(ChatKey(chat1.0), "Item").await.unwrap();
     }
-    let items = db.list_items(chat1).await.unwrap();
-    let ids: Vec<i64> = items.iter().map(|i| i.id).collect();
+    let items = db.list_items(ChatKey(chat1.0)).await.unwrap();
+    let ids: Vec<ItemId> = items.iter().map(|i| i.id).collect();
 
-    db.delete_items(chat2, &ids).await.unwrap();
-    let remaining = db.list_items(chat1).await.unwrap();
+    db.delete_items(ChatKey(chat2.0), &ids).await.unwrap();
+    let remaining = db.list_items(ChatKey(chat1.0)).await.unwrap();
     assert_eq!(remaining.len(), 3);
 }

--- a/tests/db_flow.rs
+++ b/tests/db_flow.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use shopbot::db::{ChatKey, ItemId};
 use shopbot::tests::util::init_test_db;
 use teloxide::types::{ChatId, MessageId};
 
@@ -6,25 +7,26 @@ use teloxide::types::{ChatId, MessageId};
 async fn basic_item_flow() -> Result<()> {
     let db = init_test_db().await;
     let chat = ChatId(42);
+    let key = ChatKey(chat.0);
 
-    db.add_item(chat, "Apples").await?;
-    db.add_item(chat, "Milk").await?;
+    db.add_item(key, "Apples").await?;
+    db.add_item(key, "Milk").await?;
 
-    let mut items = db.list_items(chat).await?;
+    let mut items = db.list_items(key).await?;
     assert_eq!(items.len(), 2);
     assert_eq!(items[0].text, "Apples");
     assert!(!items[0].done);
 
-    db.toggle_item(chat, items[0].id).await?;
-    items = db.list_items(chat).await?;
+    db.toggle_item(key, items[0].id).await?;
+    items = db.list_items(key).await?;
     assert!(items[0].done);
 
-    db.delete_item(chat, items[1].id).await?;
-    items = db.list_items(chat).await?;
+    db.delete_item(key, items[1].id).await?;
+    items = db.list_items(key).await?;
     assert_eq!(items.len(), 1);
 
-    db.delete_all_items(chat).await?;
-    items = db.list_items(chat).await?;
+    db.delete_all_items(key).await?;
+    items = db.list_items(key).await?;
     assert!(items.is_empty());
 
     Ok(())
@@ -34,14 +36,15 @@ async fn basic_item_flow() -> Result<()> {
 async fn last_message_id_roundtrip() -> Result<()> {
     let db = init_test_db().await;
     let chat = ChatId(1);
+    let key = ChatKey(chat.0);
 
-    assert!(db.get_last_list_message_id(chat).await?.is_none());
+    assert!(db.get_last_list_message_id(key).await?.is_none());
 
-    db.update_last_list_message_id(chat, MessageId(99)).await?;
-    assert_eq!(db.get_last_list_message_id(chat).await?, Some(99));
+    db.update_last_list_message_id(key, MessageId(99)).await?;
+    assert_eq!(db.get_last_list_message_id(key).await?, Some(99));
 
-    db.clear_last_list_message_id(chat).await?;
-    assert!(db.get_last_list_message_id(chat).await?.is_none());
+    db.clear_last_list_message_id(key).await?;
+    assert!(db.get_last_list_message_id(key).await?.is_none());
 
     Ok(())
 }
@@ -50,16 +53,17 @@ async fn last_message_id_roundtrip() -> Result<()> {
 async fn delete_multiple_items() -> Result<()> {
     let db = init_test_db().await;
     let chat = ChatId(2);
+    let key = ChatKey(chat.0);
     for i in 0..3 {
-        db.add_item(chat, &format!("Item {i}")).await?;
+        db.add_item(key, &format!("Item {i}")).await?;
     }
 
-    let items = db.list_items(chat).await?;
-    let ids: Vec<i64> = items.iter().map(|i| i.id).collect();
+    let items = db.list_items(key).await?;
+    let ids: Vec<ItemId> = items.iter().map(|i| i.id).collect();
 
-    db.delete_items(chat, &ids).await?;
+    db.delete_items(key, &ids).await?;
 
-    let remaining = db.list_items(chat).await?;
+    let remaining = db.list_items(key).await?;
     assert!(remaining.is_empty());
 
     Ok(())

--- a/tests/formatting.rs
+++ b/tests/formatting.rs
@@ -1,5 +1,5 @@
-use shopbot::{format_delete_list, format_list, format_plain_list, Item};
 use shopbot::db::ItemId;
+use shopbot::{format_delete_list, format_list, format_plain_list, Item};
 
 fn sample_items() -> Vec<Item> {
     vec![

--- a/tests/formatting.rs
+++ b/tests/formatting.rs
@@ -1,14 +1,15 @@
 use shopbot::{format_delete_list, format_list, format_plain_list, Item};
+use shopbot::db::ItemId;
 
 fn sample_items() -> Vec<Item> {
     vec![
         Item {
-            id: 1,
+            id: ItemId(1),
             text: "Apples".to_string(),
             done: false,
         },
         Item {
-            id: 2,
+            id: ItemId(2),
             text: "Milk".to_string(),
             done: true,
         },
@@ -18,12 +19,12 @@ fn sample_items() -> Vec<Item> {
 fn all_done_items() -> Vec<Item> {
     vec![
         Item {
-            id: 1,
+            id: ItemId(1),
             text: "Apples".to_string(),
             done: true,
         },
         Item {
-            id: 2,
+            id: ItemId(2),
             text: "Milk".to_string(),
             done: true,
         },
@@ -51,7 +52,7 @@ fn test_format_delete_list() {
 
     let items = sample_items();
     let mut selected = HashSet::new();
-    selected.insert(1);
+    selected.insert(ItemId(1));
     let (text, keyboard) = format_delete_list(&items, &selected);
 
     assert_eq!(text, "Select items to delete, then tap 'Done Deleting'.");


### PR DESCRIPTION
## Summary
- add `ChatKey` and `ItemId` wrappers
- use the new wrappers across database APIs and handlers
- update tests for the new types

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --all`

------
https://chatgpt.com/codex/tasks/task_e_684a83cc7c10832d867f946e243508be