### PR TITLE
Introduce shared item request builder

### DIFF
--- a/src/ai/common.rs
+++ b/src/ai/common.rs
@@ -44,14 +44,11 @@ pub fn build_text_chat_body(
     system_prompt: &str,
     user_text: &str,
 ) -> serde_json::Value {
-    serde_json::json!({
-        "model": model,
-        "response_format": { "type": "json_object" },
-        "messages": [
-            { "role": "system", "content": system_prompt },
-            { "role": "user", "content": user_text },
-        ]
-    })
+    build_items_request(
+        model,
+        system_prompt,
+        serde_json::Value::String(user_text.to_string()),
+    )
 }
 
 /// Build a chat completion request body for an image input.
@@ -60,15 +57,28 @@ pub fn build_image_chat_body(
     system_prompt: &str,
     image_url: &str,
 ) -> serde_json::Value {
+    build_items_request(
+        model,
+        system_prompt,
+        serde_json::json!([{
+            "type": "image_url",
+            "image_url": { "url": image_url },
+        }]),
+    )
+}
+
+/// Build a chat completion request body for item extraction.
+pub fn build_items_request(
+    model: &str,
+    prompt: &str,
+    user_payload: serde_json::Value,
+) -> serde_json::Value {
     serde_json::json!({
         "model": model,
         "response_format": { "type": "json_object" },
         "messages": [
-            { "role": "system", "content": system_prompt },
-            {
-                "role": "user",
-                "content": [ { "type": "image_url", "image_url": { "url": image_url } } ],
-            }
+            { "role": "system", "content": prompt },
+            { "role": "user", "content": user_payload },
         ]
     })
 }

--- a/src/ai/gpt.rs
+++ b/src/ai/gpt.rs
@@ -1,5 +1,6 @@
-use crate::ai::common::{request_items, OPENAI_CHAT_URL};
+use crate::ai::common::{build_items_request, request_items, OPENAI_CHAT_URL};
 use anyhow::Result;
+use serde_json::Value;
 use tracing::instrument;
 
 /// Use the OpenAI Chat API to parse items from arbitrary text.
@@ -26,7 +27,7 @@ pub async fn parse_items_gpt_inner(
     url: &str,
 ) -> Result<Vec<String>> {
     let prompt = "Extract the items from the user's text. Use the nominative form for nouns when it does not change the meaning. Convert number words to digits so 'три ананаса' becomes '3 ананаса'. Respond with a JSON object like {\"items\": [\"1 milk\"]}";
-    let body = crate::ai::common::build_text_chat_body(model, prompt, text);
+    let body = build_items_request(model, prompt, Value::String(text.to_string()));
 
     request_items(api_key, &body, url).await
 }

--- a/src/ai/vision.rs
+++ b/src/ai/vision.rs
@@ -1,6 +1,7 @@
-use crate::ai::common::{request_items, OPENAI_CHAT_URL};
+use crate::ai::common::{build_items_request, request_items, OPENAI_CHAT_URL};
 use anyhow::Result;
 use base64::Engine as _;
+use serde_json::json;
 use tracing::instrument;
 
 #[instrument(level = "trace", skip(api_key, bytes))]
@@ -25,7 +26,11 @@ pub async fn parse_photo_items_inner(
     let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
     let data_url = format!("data:image/png;base64,{}", encoded);
     let prompt = "Extract the items shown in the photo. Respond with a JSON object like {\"items\": [\"apples\"]}.";
-    let body = crate::ai::common::build_image_chat_body(model, prompt, &data_url);
+    let body = build_items_request(
+        model,
+        prompt,
+        json!([{ "type": "image_url", "image_url": { "url": data_url } }]),
+    );
 
     request_items(api_key, &body, url).await
 }


### PR DESCRIPTION
## Summary
- add `build_items_request` in `src/ai/common.rs`
- reuse the helper in `parse_photo_items_inner` and `parse_items_gpt_inner`
- keep prompts local while centralising body creation

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --all`

------
https://chatgpt.com/codex/tasks/task_e_684a83cd35c8832db5439e3c3ef908ed