### PR TITLE
Add Telegram file download helper

### DIFF
--- a/src/handlers/photo.rs
+++ b/src/handlers/photo.rs
@@ -1,5 +1,5 @@
 use crate::db::Database;
-use crate::utils::download_file;
+use crate::utils::download_telegram_file;
 use anyhow::Result;
 use teloxide::prelude::*;
 
@@ -32,9 +32,7 @@ pub async fn add_items_from_photo(
         return Ok(());
     };
 
-    let file = bot.get_file(file_id).await?;
-    let bytes = download_file(&bot, &file.path).await?;
-    tracing::trace!(size = bytes.len(), "downloaded photo bytes");
+    let bytes = download_telegram_file(&bot, file_id).await?;
 
     tracing::debug!(model = %config.vision_model, "parsing photo with OpenAI vision");
     let items = match parse_photo_items(

--- a/src/handlers/voice.rs
+++ b/src/handlers/voice.rs
@@ -1,5 +1,5 @@
 use crate::db::Database;
-use crate::utils::download_file;
+use crate::utils::download_telegram_file;
 use anyhow::Result;
 use teloxide::prelude::*;
 
@@ -51,8 +51,7 @@ pub async fn add_items_from_voice(
         None => return Ok(()),
     };
 
-    let file = bot.get_file(&voice.file.id).await?;
-    let audio = download_file(&bot, &file.path).await?;
+    let audio = download_telegram_file(&bot, &voice.file.id).await?;
 
     match transcribe_audio(
         &config.stt_model,


### PR DESCRIPTION
## Summary
- add `download_telegram_file` helper for bot files
- switch photo and voice handlers to use the helper
- log the download path and final size
- test the helper

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --all`

------
https://chatgpt.com/codex/tasks/task_e_684a83ce6b6c832d99777689f64c548c