### PR TITLE
Unify chat body builder

### DIFF
--- a/src/ai/common.rs
+++ b/src/ai/common.rs
@@ -38,37 +38,18 @@ struct ItemsJson {
 
 pub const OPENAI_CHAT_URL: &str = "https://api.openai.com/v1/chat/completions";
 
-/// Build a chat completion request body for text input.
-pub fn build_text_chat_body(
+/// Build a chat completion request body with arbitrary user content.
+pub fn build_chat_body(
     model: &str,
     system_prompt: &str,
-    user_text: &str,
+    user_content: serde_json::Value,
 ) -> serde_json::Value {
     serde_json::json!({
         "model": model,
         "response_format": { "type": "json_object" },
         "messages": [
             { "role": "system", "content": system_prompt },
-            { "role": "user", "content": user_text },
-        ]
-    })
-}
-
-/// Build a chat completion request body for an image input.
-pub fn build_image_chat_body(
-    model: &str,
-    system_prompt: &str,
-    image_url: &str,
-) -> serde_json::Value {
-    serde_json::json!({
-        "model": model,
-        "response_format": { "type": "json_object" },
-        "messages": [
-            { "role": "system", "content": system_prompt },
-            {
-                "role": "user",
-                "content": [ { "type": "image_url", "image_url": { "url": image_url } } ],
-            }
+            { "role": "user", "content": user_content },
         ]
     })
 }

--- a/src/ai/gpt.rs
+++ b/src/ai/gpt.rs
@@ -26,7 +26,7 @@ pub async fn parse_items_gpt_inner(
     url: &str,
 ) -> Result<Vec<String>> {
     let prompt = "Extract the items from the user's text. Use the nominative form for nouns when it does not change the meaning. Convert number words to digits so 'три ананаса' becomes '3 ананаса'. Respond with a JSON object like {\"items\": [\"1 milk\"]}";
-    let body = crate::ai::common::build_text_chat_body(model, prompt, text);
+    let body = crate::ai::common::build_chat_body(model, prompt, serde_json::json!(text));
 
     request_items(api_key, &body, url).await
 }
@@ -75,7 +75,7 @@ pub async fn interpret_voice_command_inner(
         "You manage a list of items. {list_text} The list as JSON is {list_json}. Decide whether the user's request adds items or removes items from the list. Return a JSON object like {{\"add\":[...]}} or {{\"delete\":[...]}}. For deletions, include each item exactly as it appears in the list, including any leading quantities. If unsure, treat it as an addition request. Use nominative forms for item names when possible and convert number words to digits."
     );
 
-    let body = crate::ai::common::build_text_chat_body(model, &prompt, text);
+    let body = crate::ai::common::build_chat_body(model, &prompt, serde_json::json!(text));
 
     use tracing::{debug, trace};
 

--- a/src/ai/vision.rs
+++ b/src/ai/vision.rs
@@ -25,7 +25,11 @@ pub async fn parse_photo_items_inner(
     let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
     let data_url = format!("data:image/png;base64,{}", encoded);
     let prompt = "Extract the items shown in the photo. Respond with a JSON object like {\"items\": [\"apples\"]}.";
-    let body = crate::ai::common::build_image_chat_body(model, prompt, &data_url);
+    let body = crate::ai::common::build_chat_body(
+        model,
+        prompt,
+        serde_json::json!([ { "type": "image_url", "image_url": { "url": &data_url } } ]),
+    );
 
     request_items(api_key, &body, url).await
 }


### PR DESCRIPTION
## Summary
- consolidate `build_text_chat_body` and `build_image_chat_body`
- use new `build_chat_body` in GPT and vision helpers

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --all`

------
https://chatgpt.com/codex/tasks/task_e_684a83d0d558832d9a65100d0969842f