### PR TITLE
Install protobuf compiler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - name: Cargo fmt
         run: cargo fmt --all -- --check
       - name: Cargo clippy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 6. Temporary message timeout configurable via `DELETE_AFTER_TIMEOUT`.
 7. Default SQLite path renamed to `items.db`.
 8. User-facing messages use generic item list wording.
+9. Building now requires the `protobuf-compiler` package.
 
 ## [0.3.0] - 2025-06-09
 1. `/info` command shows commit hash and release version or how many commits the build is ahead of the latest release

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN cargo chef prepare --recipe-path recipe.json
 FROM rust:1.87-slim AS cacher
 WORKDIR /app
 # Install system dependencies required for building crates like `openssl-sys`
-RUN apt-get update -qq && apt-get install -y --no-install-recommends git pkg-config libssl-dev
+RUN apt-get update -qq && apt-get install -y --no-install-recommends git pkg-config libssl-dev protobuf-compiler
 RUN cargo install cargo-chef
 COPY --from=planner /app/recipe.json recipe.json
 # Build dependencies
@@ -25,7 +25,7 @@ RUN cargo chef cook --release --recipe-path recipe.json
 FROM rust:1.87-slim AS builder
 WORKDIR /app
 # Install system dependencies required for the final link
-RUN apt-get update -qq && apt-get install -y --no-install-recommends git pkg-config libssl-dev
+RUN apt-get update -qq && apt-get install -y --no-install-recommends git pkg-config libssl-dev protobuf-compiler
 COPY . .
 # Copy over the pre-built dependencies from the cacher stage
 COPY --from=cacher /app/target target

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Send any message to the bot. Every non-empty line becomes an item. If you send a
 
 ## Installation
 
-1. Install a recent [Rust toolchain](https://www.rust-lang.org/tools/install).
+1. Install a recent [Rust toolchain](https://www.rust-lang.org/tools/install) and the `protobuf-compiler` package.
 2. Clone this repository and build the binary:
    ```bash
    cargo build --release


### PR DESCRIPTION
## Summary
- update CI to install `protobuf-compiler`
- install `protobuf-compiler` in Docker builder images
- mention `protobuf-compiler` in installation instructions
- record prerequisite in CHANGELOG

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --all`


------
https://chatgpt.com/codex/tasks/task_e_684bf6ae87f0832dbce3f237f2659105