### PR TITLE
Add /done command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 6. Temporary message timeout configurable via `DELETE_AFTER_TIMEOUT`.
 7. Default SQLite path renamed to `items.db`.
 8. User-facing messages use generic item list wording.
+9. Added `/done` command to archive checked items without clearing the whole list.
 
 ## [0.3.0] - 2025-06-09
 1. `/info` command shows commit hash and release version or how many commits the build is ahead of the latest release

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Send any message to the bot. Every non-empty line becomes an item. If you send a
 
 - `/list` – show the list again
 - `/archive` – archive the current list and start a new one
+- `/done` – archive only checked items and keep the rest
 - `/delete` – select items to remove
 - `/share` – send the list as plain text
 - `/nuke` – wipe the list completely

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -14,6 +14,11 @@ pub enum Command {
     List,
     #[command(description = "finalize and archive the current list, starting a new one.")]
     Archive,
+    #[command(
+        rename = "done",
+        description = "archive only checked items and keep the rest."
+    )]
+    ArchiveDone,
     #[command(description = "show a temporary panel to delete items from the list.")]
     Delete,
     #[command(description = "send the list as plain text for copying.")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,9 @@ pub async fn run() -> Result<()> {
                             Command::Start | Command::Help => help(bot, msg).await?,
                             Command::List => service.send_list(bot, msg.chat.id).await?,
                             Command::Archive => service.archive(bot, msg.chat.id).await?,
+                            Command::ArchiveDone => {
+                                service.archive_checked(bot, msg.chat.id).await?
+                            }
                             Command::Delete => {
                                 enter_delete_mode(bot, msg, &db, delete_after_timeout).await?
                             }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -9,6 +9,7 @@ pub const HELP_TEXT: &str =
              <b>Commands:</b>\n\
              /list - Show the current list.\n\
              /archive - Finalize and archive the current list, starting a new one.\n\
+             /done - Archive only checked items, keeping the rest.\n\
              /delete - Show a temporary panel to delete items from the list.\n\
              /share - Send the list as plain text for copying.\n\
              /nuke - Completely delete the current list.\n\
@@ -25,6 +26,8 @@ pub const LIST_EMPTY: &str = "Your list is empty!";
 pub const LIST_NOW_EMPTY: &str = "List is now empty!";
 pub const LIST_ARCHIVED: &str = "List archived! Send a message to start a new one.";
 pub const LIST_NUKED: &str = "The active list has been nuked.";
+pub const CHECKED_ITEMS_ARCHIVED: &str = "Checked items archived!";
+pub const NO_CHECKED_ITEMS_TO_ARCHIVE: &str = "There are no checked items to archive.";
 
 pub const DELETE_SELECT_PROMPT: &str = "Select items to delete, then tap 'Done Deleting'.";
 pub const DELETE_DONE_LABEL: &str = "🗑️ Done Deleting";

--- a/tests/archive_checked.rs
+++ b/tests/archive_checked.rs
@@ -1,0 +1,80 @@
+use shopbot::tests::util::init_test_db;
+use shopbot::{ListService, NO_CHECKED_ITEMS_TO_ARCHIVE};
+use teloxide::{prelude::*, types::MessageId};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn archive_checked_archives_only_done() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/botTEST/EditMessageText"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_raw(r#"{"ok":true,"result":true}"#, "application/json"),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/botTEST/SendMessage"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            r#"{"ok":true,"result":{"message_id":42,"date":0,"chat":{"id":1,"type":"private"},"text":"t"}}"#,
+            "application/json",
+        ))
+        .expect(2)
+        .mount(&server)
+        .await;
+
+    let bot = Bot::new("TEST").set_api_url(reqwest::Url::parse(&server.uri()).unwrap());
+    let db = init_test_db().await;
+    let chat = ChatId(1);
+    db.add_item(chat, "Milk").await.unwrap();
+    db.add_item(chat, "Eggs").await.unwrap();
+    let items = db.list_items(chat).await.unwrap();
+    db.toggle_item(chat, items[0].id).await.unwrap();
+    db.update_last_list_message_id(chat, MessageId(5))
+        .await
+        .unwrap();
+
+    ListService::new(&db)
+        .archive_checked(bot, chat)
+        .await
+        .unwrap();
+
+    let remaining = db.list_items(chat).await.unwrap();
+    assert_eq!(remaining.len(), 1);
+    assert_eq!(remaining[0].text, "Eggs");
+    server.verify().await;
+}
+
+#[tokio::test]
+async fn archive_checked_none_done() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/botTEST/SendMessage"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            format!(r#"{{"ok":true,"result":{{"message_id":1,"date":0,"chat":{{"id":1,"type":"private"}},"text":"{}"}}}}"#, NO_CHECKED_ITEMS_TO_ARCHIVE),
+            "application/json",
+        ))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let bot = Bot::new("TEST").set_api_url(reqwest::Url::parse(&server.uri()).unwrap());
+    let db = init_test_db().await;
+    let chat = ChatId(1);
+    db.add_item(chat, "Milk").await.unwrap();
+    db.update_last_list_message_id(chat, MessageId(3))
+        .await
+        .unwrap();
+
+    ListService::new(&db)
+        .archive_checked(bot, chat)
+        .await
+        .unwrap();
+
+    let remaining = db.list_items(chat).await.unwrap();
+    assert_eq!(remaining.len(), 1);
+    server.verify().await;
+}

--- a/tests/dispatcher_flow.rs
+++ b/tests/dispatcher_flow.rs
@@ -10,6 +10,8 @@ enum Command {
     Help,
     List,
     Archive,
+    #[command(rename = "done")]
+    ArchiveDone,
     Delete,
     Share,
     Nuke,
@@ -60,6 +62,9 @@ async fn dispatcher_add_then_list() {
                             Command::Start | Command::Help => shopbot::help(bot, msg).await?,
                             Command::List => service.send_list(bot, msg.chat.id).await?,
                             Command::Archive => service.archive(bot, msg.chat.id).await?,
+                            Command::ArchiveDone => {
+                                service.archive_checked(bot, msg.chat.id).await?
+                            }
                             Command::Delete => {
                                 shopbot::enter_delete_mode(bot, msg, &db, delete_after_timeout)
                                     .await?


### PR DESCRIPTION
## Summary
- shorten `/archive_checked` command to `/done`
- update help text, README, and changelog
- adjust dispatcher flow test and command enum for the new name

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --all`


------
https://chatgpt.com/codex/tasks/task_e_6857bc292e80832dbe6b1f3c81ed25f7