### PR TITLE
Fix message order for list archiving

### DIFF
--- a/tests/archive_checked.rs
+++ b/tests/archive_checked.rs
@@ -8,7 +8,7 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 async fn archive_checked_archives_only_done() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
-        .and(path("/botTEST/EditMessageText"))
+        .and(path("/botTEST/DeleteMessage"))
         .respond_with(
             ResponseTemplate::new(200)
                 .set_body_raw(r#"{"ok":true,"result":true}"#, "application/json"),
@@ -19,10 +19,10 @@ async fn archive_checked_archives_only_done() {
     Mock::given(method("POST"))
         .and(path("/botTEST/SendMessage"))
         .respond_with(ResponseTemplate::new(200).set_body_raw(
-            r#"{"ok":true,"result":{"message_id":42,"date":0,"chat":{"id":1,"type":"private"},"text":"t"}}"#,
+            r#"{"ok":true,"result":{"message_id":1,"date":0,"chat":{"id":1,"type":"private"},"text":"archived"}}"#,
             "application/json",
         ))
-        .expect(2)
+        .expect(3)
         .mount(&server)
         .await;
 

--- a/tests/archive_nuke.rs
+++ b/tests/archive_nuke.rs
@@ -1,5 +1,5 @@
 use shopbot::tests::util::init_test_db;
-use shopbot::{ListService, LIST_ARCHIVED, LIST_NUKED};
+use shopbot::{ListService, LIST_NUKED};
 use teloxide::{
     prelude::*,
     types::{Message, MessageId},
@@ -11,7 +11,7 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 async fn archive_clears_data_and_sends_confirmation() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
-        .and(path("/botTEST/EditMessageText"))
+        .and(path("/botTEST/DeleteMessage"))
         .respond_with(
             ResponseTemplate::new(200)
                 .set_body_raw(r#"{"ok":true,"result":true}"#, "application/json"),
@@ -22,10 +22,10 @@ async fn archive_clears_data_and_sends_confirmation() {
     Mock::given(method("POST"))
         .and(path("/botTEST/SendMessage"))
         .respond_with(ResponseTemplate::new(200).set_body_raw(
-            format!(r#"{{"ok":true,"result":{{"message_id":1,"date":0,"chat":{{"id":1,"type":"private"}},"text":"{}"}}}}"#, LIST_ARCHIVED),
+            r#"{"ok":true,"result":{"message_id":2,"date":0,"chat":{"id":1,"type":"private"},"text":"archived"}}"#,
             "application/json",
         ))
-        .expect(1)
+        .expect(2)
         .mount(&server)
         .await;
 


### PR DESCRIPTION
## Summary
- edit archive commands to delete old list message and send archived list below the command
- adjust archive_checked to send confirmation before new list
- update integration tests for new behavior

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --all`


------
https://chatgpt.com/codex/tasks/task_e_6857d1fcd3f0832db2c0a7ff013a5dd9